### PR TITLE
Adding constraints around naming test waiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This addon implements the design specified in [RFC 581](https://github.com/ember
 - [Installation](#installation)
 - [Quickstart](#quickstart)
   - [buildWaiter function](#buildwaiter-function)
+    - [Waiter naming conventions](#waiter-naming-conventions)
   - [waitForPromise function](#waitforpromise-function)
   - [Waiting on all waiters](#waiting-on-all-waiters)
 - [General Design](#general-design)
@@ -59,17 +60,31 @@ that provides a number of methods. The key methods that allow you to control asy
 a pair to _begin_ waiting and _end_ waiting respectively. The `beginAsync` method returns a `token`, which uniquely identifies that async operation. To mark the
 async operation as complete, call `endAsync`, passing in the `token` that was returned from the prior `beginAsync` call.
 
+#### Waiter naming conventions
+
+When building your waiter, you should ensure you use a meaningful name. At a minimum, your name needs to be constructed of a `namespace`, and optionally a `descriptor` in the format `namespace[:descriptor]`. Suggestions for naming conventions are as follows:
+
+For apps:
+
+1. `file-name` - if your file has only one waiter, the file name becomes the namespace
+1. `file-name:waiter-1`, `file-name:waiter-2`, ... - if your file has more than one waiter, the file name becomes the namespace and we add descriptors
+
+For addons:
+
+1. `addon-name` - if your addon has only one waiter, the addon name becomes the namespace
+1. `addon-name:waiter-1`, `addon-name:waiter-2`, ... - if your addon has more than one waiter, the addon name becomes the namespace and we add descriptors
+
 ```js
 import Component from '@ember/component';
 import { buildWaiter } from 'ember-test-waiters';
 
-let waiter = buildWaiter('friend-waiter');
+let waiter = buildWaiter('ember-friendz:friend-waiter');
 
 export default class Friendz extends Component {
   didInsertElement() {
     let token = waiter.beginAsync();
 
-    someAsyncWork()
+    makeFriendz()
       .then(() => {
         //... some work
       })
@@ -91,8 +106,8 @@ import { waitForPromise } from 'ember-test-waiters';
 
 export default class MoreFriendz extends Component {
   didInsertElement() {
-    waitForPromise(someAsyncWork).then(() => {
-      doOtherThings();
+    waitForPromise(makeFriendz).then(() => {
+      return goForDrinks();
     });
   }
 }

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -17,5 +17,5 @@ export {
   hasPendingWaiters,
 } from './waiter-manager';
 
-export { default as buildWaiter } from './build-waiter';
+export { default as buildWaiter, _resetWaiterNames } from './build-waiter';
 export { default as waitForPromise } from './wait-for-promise';

--- a/addon/wait-for-promise.ts
+++ b/addon/wait-for-promise.ts
@@ -2,7 +2,7 @@ import { DEBUG } from '@glimmer/env';
 import RSVP from 'rsvp';
 import buildWaiter from './build-waiter';
 
-const PROMISE_WAITER = buildWaiter('promise-waiter');
+const PROMISE_WAITER = buildWaiter('ember-test-waiters:promise-waiter');
 
 type PromiseType<T> = Promise<T> | RSVP.Promise<T>;
 

--- a/tests/unit/wait-for-promise-test.ts
+++ b/tests/unit/wait-for-promise-test.ts
@@ -30,7 +30,7 @@ if (DEBUG) {
         assert.deepEqual(getPendingWaiterState(), {
           pending: 1,
           waiters: {
-            'promise-waiter': [
+          'ember-test-waiters:promise-waiter': [
               {
                 label: undefined,
                 stack: 'STACK',

--- a/tests/unit/wait-for-promise-test.ts
+++ b/tests/unit/wait-for-promise-test.ts
@@ -30,7 +30,7 @@ if (DEBUG) {
         assert.deepEqual(getPendingWaiterState(), {
           pending: 1,
           waiters: {
-          'ember-test-waiters:promise-waiter': [
+            'ember-test-waiters:promise-waiter': [
               {
                 label: undefined,
                 stack: 'STACK',
@@ -87,7 +87,7 @@ if (DEBUG) {
         assert.deepEqual(getPendingWaiterState(), {
           pending: 1,
           waiters: {
-            'promise-waiter': [
+            'ember-test-waiters:promise-waiter': [
               {
                 label: undefined,
                 stack: 'STACK',

--- a/tests/unit/waiter-manager-noop-test.ts
+++ b/tests/unit/waiter-manager-noop-test.ts
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 import { DEBUG } from '@glimmer/env';
 
 if (!DEBUG) {
-  module('test-waiter | DEBUG: false', function(hooks) {
+  module('waiter-manager-noop | DEBUG: false', function(hooks) {
     hooks.afterEach(function() {
       _reset();
     });
@@ -20,16 +20,16 @@ if (!DEBUG) {
     });
 
     test('register will correctly add a waiter', function(assert) {
-      let waiter = buildWaiter('first');
+      let waiter = buildWaiter('ember-test-waiters:first');
 
       register(waiter);
 
       let waiters = getWaiters().map(w => w.name);
-      assert.deepEqual(waiters, ['first']);
+      assert.deepEqual(waiters, ['ember-test-waiters:first']);
     });
 
     test('a NoopTestWaiter always returns true from waitUntil', function(assert) {
-      let waiter = buildWaiter('first');
+      let waiter = buildWaiter('ember-test-waiters:first');
 
       assert.ok(waiter.waitUntil(), 'waitUntil returns true');
       let token = waiter.beginAsync();
@@ -39,7 +39,7 @@ if (!DEBUG) {
     });
 
     test('a NoopTestWaiter always returns true from waitUntil', function(assert) {
-      let waiter = buildWaiter('first');
+      let waiter = buildWaiter('ember-test-waiters:first');
       let waiterItem = {};
 
       assert.ok(waiter.waitUntil(), 'waitUntil returns true');

--- a/tests/unit/waiter-manager-test.ts
+++ b/tests/unit/waiter-manager-test.ts
@@ -3,6 +3,7 @@ import { TestWaiterDebugInfo, Waiter, WaiterName } from 'ember-test-waiters/type
 import {
   Token,
   _reset,
+  _resetWaiterNames,
   buildWaiter,
   getPendingWaiterState,
   getWaiters,
@@ -13,41 +14,45 @@ import {
 import { module, test } from 'qunit';
 
 import { DEBUG } from '@glimmer/env';
+import { registerWarnHandler } from '@ember/debug';
 
 if (DEBUG) {
-  module('test-waiters | DEBUG: true', function(hooks) {
+  module('waiter-manager | DEBUG: true', function(hooks) {
     hooks.afterEach(function() {
       _reset();
+      _resetWaiterNames();
       resetError();
+
+      registerWarnHandler(() => {});
     });
 
     test('register will correctly add a waiter', function(assert) {
-      let waiter = buildWaiter('first');
+      let waiter = buildWaiter('ember-test-waiters:first');
 
       register(waiter);
 
       let waiters = getWaiters().map(w => w.name);
-      assert.deepEqual(waiters, ['first']);
+      assert.deepEqual(waiters, ['ember-test-waiters:first']);
     });
 
     test('register will only add one waiter with the same name', function(assert) {
-      let waiter = buildWaiter('first');
-      let secondWaiterButStillCalledFirst = buildWaiter('first');
+      let waiter = buildWaiter('ember-test-waiters:first');
+      let secondWaiterButStillCalledFirst = buildWaiter('ember-test-waiters:first');
 
       register(waiter);
       register(secondWaiterButStillCalledFirst);
 
       let waiters = getWaiters().map(w => w.name);
-      assert.deepEqual(waiters, ['first']);
+      assert.deepEqual(waiters, ['ember-test-waiters:first']);
     });
 
     test('unregister will correctly remove a waiter', function(assert) {
-      let waiter = buildWaiter('first');
+      let waiter = buildWaiter('ember-test-waiters:first');
 
       register(waiter);
 
       let waiters = getWaiters().map(w => w.name);
-      assert.deepEqual(waiters, ['first'], 'precond');
+      assert.deepEqual(waiters, ['ember-test-waiters:first'], 'precond');
 
       unregister(waiter);
 
@@ -56,7 +61,7 @@ if (DEBUG) {
     });
 
     test('getWaiters returns all registered waiters', function(assert) {
-      let waiter = buildWaiter('first');
+      let waiter = buildWaiter('ember-test-waiters:first');
 
       assert.equal(getWaiters(), 0, 'No waiters are registered');
 
@@ -70,8 +75,8 @@ if (DEBUG) {
     });
 
     test('getPendingWaiterState returns information on pending waiters', function(assert) {
-      let first = buildWaiter('first');
-      let second = buildWaiter('second');
+      let first = buildWaiter('ember-test-waiters:first');
+      let second = buildWaiter('ember-test-waiters:second');
       let firstItem = {};
       let secondItem = {};
 
@@ -85,7 +90,7 @@ if (DEBUG) {
       assert.deepEqual(
         getPendingWaiterState().waiters,
         {
-          first: [
+          'ember-test-waiters:first': [
             {
               label: undefined,
               stack: 'STACK',
@@ -106,7 +111,7 @@ if (DEBUG) {
       assert.deepEqual(
         getPendingWaiterState().waiters,
         {
-          second: [
+          'ember-test-waiters:second': [
             {
               label: undefined,
               stack: 'STACK',
@@ -123,8 +128,8 @@ if (DEBUG) {
     });
 
     test('getPendingWaiterState contains label info when label provided', function(assert) {
-      let first = buildWaiter('first');
-      let second = buildWaiter('second');
+      let first = buildWaiter('ember-test-waiters:first');
+      let second = buildWaiter('ember-test-waiters:second');
       let firstItem = {};
       let secondItem = {};
 
@@ -136,13 +141,13 @@ if (DEBUG) {
       assert.deepEqual(getPendingWaiterState(), {
         pending: 2,
         waiters: {
-          first: [
+          'ember-test-waiters:first': [
             {
               label: 'first-label',
               stack: 'STACK',
             },
           ],
-          second: [
+          'ember-test-waiters:second': [
             {
               label: 'second-label',
               stack: 'STACK',
@@ -153,8 +158,8 @@ if (DEBUG) {
     });
 
     test('hasPendingWaiters can check if waiting is required', function(assert) {
-      let first = buildWaiter('first');
-      let second = buildWaiter('second');
+      let first = buildWaiter('ember-test-waiters:first');
+      let second = buildWaiter('ember-test-waiters:second');
       let firstItem = {};
       let secondItem = {};
 
@@ -204,7 +209,7 @@ if (DEBUG) {
         }
       }
 
-      customWaiter = new CustomWaiter('custom-waiter');
+      customWaiter = new CustomWaiter('ember-test-waiters:custom-waiter');
 
       register(customWaiter);
 


### PR DESCRIPTION
This PR adds some constrains around the naming of test waiters. Specifically, it adds a pattern (`namespace:descriptor`) for test waiters in order to help identify them. Currently this is implemented as a warning, to avoid a breaking change.

[README](https://github.com/emberjs/ember-test-waiters/blob/waiter-label-naming/README.md) changes.