### PR TITLE
Extend waitForPromise to work in function form

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,14 +116,35 @@ export default class MoreFriendz extends Component {
 }
 ```
 
-It can also be used in decorator form to wrap an async function so calls to it are registered with the test waiter system.
+### waitFor function
+
+Similar to the `waitForPromise` function, the `waitFor` function can be use to wait for async calls. It can be used with async functions, and in decorator form to wrap an async function so calls to it are registered with the test waiter system.
 
 ```js
+// wrapping async functions
 import Component from '@ember/component';
-import { waitForPromise } from 'ember-test-waiters';
+import { waitFor } from 'ember-test-waiters';
+
+export default Component.extend({
+  doAsyncStuff: waitFor(async function doAsyncStuff() {
+    await someAsyncWork();
+  }),
+
+  didInsertElement() {
+    this.doAsyncStuff().then(() => {
+      doOtherThings();
+    });
+  },
+});
+```
+
+```js
+// decorator form
+import Component from '@ember/component';
+import { waitFor } from 'ember-test-waiters';
 
 export default class MoreFriendz extends Component {
-  @waitForPromise
+  @waitFor
   async doAsyncStuff() {
     await someAsyncWork();
   }
@@ -134,25 +155,6 @@ export default class MoreFriendz extends Component {
     });
   }
 }
-```
-
-or in non-decorator form to wrap an async function.
-
-```js
-import Component from '@ember/component';
-import { waitForPromise } from 'ember-test-waiters';
-
-export default Component.extend({
-  doAsyncStuff: waitForPromise(async function doAsyncStuff() {
-    await someAsyncWork();
-  }),
-
-  didInsertElement() {
-    this.doAsyncStuff().then(() => {
-      doOtherThings();
-    });
-  }
-})
 ```
 
 ### Waiting on all waiters

--- a/README.md
+++ b/README.md
@@ -116,6 +116,45 @@ export default class MoreFriendz extends Component {
 }
 ```
 
+It can also be used in decorator form to wrap an async function so calls to it are registered with the test waiter system.
+
+```js
+import Component from '@ember/component';
+import { waitForPromise } from 'ember-test-waiters';
+
+export default class MoreFriendz extends Component {
+  @waitForPromise
+  async doAsyncStuff() {
+    await someAsyncWork();
+  }
+
+  didInsertElement() {
+    this.doAsyncStuff().then(() => {
+      doOtherThings();
+    });
+  }
+}
+```
+
+or in non-decorator form to wrap an async function.
+
+```js
+import Component from '@ember/component';
+import { waitForPromise } from 'ember-test-waiters';
+
+export default Component.extend({
+  doAsyncStuff: waitForPromise(async function doAsyncStuff() {
+    await someAsyncWork();
+  }),
+
+  didInsertElement() {
+    this.doAsyncStuff().then(() => {
+      doOtherThings();
+    });
+  }
+})
+```
+
 ### Waiting on all waiters
 
 The `@ember/test-waiters` addon provides a `waiter-manager` to register, unregister, iterate and invoke waiters to determine if we should wait for conditions to be met or continue test execution. This functionality is encapsulated in the `hasPendingWaiters` function, which evaluates each registered waiter to determine its current state.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ export default class Friendz extends Component {
   funcWithAsync() {
     let token = waiter.beginAsync();
 
-    makeFriendz()
+    return makeFriendz()
       .then(() => {
         //... some work
       })
@@ -109,7 +109,7 @@ import { waitForPromise } from '@ember/test-waiters';
 
 export default class MoreFriendz extends Component {
   funcWithAsync() {
-    waitForPromise(makeFriendz).then(() => {
+    return waitForPromise(makeFriendz).then(() => {
       return goForDrinks();
     });
   }
@@ -131,7 +131,7 @@ export default Component.extend({
   }),
 
   funcWithAsync() {
-    this.doAsyncStuff().then(() => {
+    return this.doAsyncStuff().then(() => {
       doOtherThings();
     });
   },
@@ -150,7 +150,7 @@ export default class MoreFriendz extends Component {
   }
 
   funcWithAsync() {
-    this.doAsyncStuff().then(() => {
+    return this.doAsyncStuff().then(() => {
       doOtherThings();
     });
   }

--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ For addons:
 1. `addon-name:waiter-1`, `addon-name:waiter-2`, ... - if your addon has more than one waiter, the addon name becomes the namespace and we add descriptors
 
 ```js
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { buildWaiter } from '@ember/test-waiters';
 
 let waiter = buildWaiter('ember-friendz:friend-waiter');
 
 export default class Friendz extends Component {
-  didInsertElement() {
+  funcWithAsync() {
     let token = waiter.beginAsync();
 
     makeFriendz()
@@ -104,11 +104,11 @@ This addon also provides a `waitForPromise` function, which can be used to wrap 
 `waitForPromise` function will ensure that `endAsync` is called correctly in the `finally` call of your promise.
 
 ```js
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { waitForPromise } from '@ember/test-waiters';
 
 export default class MoreFriendz extends Component {
-  didInsertElement() {
+  funcWithAsync() {
     waitForPromise(makeFriendz).then(() => {
       return goForDrinks();
     });
@@ -122,7 +122,7 @@ Similar to the `waitForPromise` function, the `waitFor` function can be use to w
 
 ```js
 // wrapping async functions
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { waitFor } from 'ember-test-waiters';
 
 export default Component.extend({
@@ -130,7 +130,7 @@ export default Component.extend({
     await someAsyncWork();
   }),
 
-  didInsertElement() {
+  funcWithAsync() {
     this.doAsyncStuff().then(() => {
       doOtherThings();
     });
@@ -140,7 +140,7 @@ export default Component.extend({
 
 ```js
 // decorator form
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { waitFor } from 'ember-test-waiters';
 
 export default class MoreFriendz extends Component {
@@ -149,7 +149,7 @@ export default class MoreFriendz extends Component {
     await someAsyncWork();
   }
 
-  didInsertElement() {
+  funcWithAsync() {
     this.doAsyncStuff().then(() => {
       doOtherThings();
     });
@@ -236,13 +236,13 @@ The new system captures an error object when the waiter's `beginAsync` method is
 The new test waiters system looks like this:
 
 ```js
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { buildWaiter } from '@ember/test-waiters';
 
 let waiter = buildWaiter('friend-waiter');
 
 export default class Friendz extends Component {
-  didInsertElement() {
+  funcWithAsync() {
     let token = waiter.beginAsync();
 
     someAsyncWork()
@@ -323,7 +323,7 @@ The API used to signal whether an asynchronous operation has begun and ultimatel
 To annotate the example provided above:
 
 ```js
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { buildWaiter } from '@ember/test-waiters';
 
 // Creates a test waiter with the name 'friend-waiter' that
@@ -331,7 +331,7 @@ import { buildWaiter } from '@ember/test-waiters';
 let waiter = buildWaiter('friend-waiter');
 
 export default class Friendz extends Component {
-  didInsertElement() {
+  funcWithAsync() {
     // Alerts the test waiter system that an async operation has started,
     // storing the resulting unique token to be used to notify the test
     // waiter system that the operation has ended.
@@ -355,11 +355,11 @@ export default class Friendz extends Component {
 The `waitForPromise` utility provides a convenience wrapper around the `TestWaiter` class for use with promises. It ensures the `endAsync` call is invoked in the `finally` of the configured promise.
 
 ```js
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { waitForPromise } from '@ember/test-waiters';
 
 export default class MoreFriendz extends Component {
-  didInsertElement() {
+  funcWithAsync() {
     waitForPromise(someAsyncWork).then(() => {
       doOtherThings();
     });

--- a/addon/ember-test-waiters/index.ts
+++ b/addon/ember-test-waiters/index.ts
@@ -19,3 +19,4 @@ export {
 
 export { default as buildWaiter, _resetWaiterNames } from './build-waiter';
 export { default as waitForPromise } from './wait-for-promise';
+export { default as waitFor } from './wait-for';

--- a/addon/ember-test-waiters/types/index.ts
+++ b/addon/ember-test-waiters/types/index.ts
@@ -1,3 +1,5 @@
+import RSVP from 'rsvp';
+
 /**
  * @type WaiterName
  *
@@ -105,4 +107,10 @@ export interface PendingWaiterState {
   waiters: {
     [waiterName: string]: TestWaiterDebugInfo[] | true;
   };
+}
+
+export type PromiseType<T> = Promise<T> | RSVP.Promise<T>;
+
+export interface Thenable<T, Return extends PromiseType<T>> {
+  then(resolve: (value: T) => T, reject?: (error: Error) => T): Return;
 }

--- a/addon/ember-test-waiters/wait-for-promise.ts
+++ b/addon/ember-test-waiters/wait-for-promise.ts
@@ -1,19 +1,12 @@
 import { DEBUG } from '@glimmer/env';
-import RSVP from 'rsvp';
 import buildWaiter from './build-waiter';
+
+import { PromiseType, Thenable } from './types';
 
 const PROMISE_WAITER = buildWaiter('ember-test-waiters:promise-waiter');
 
-type PromiseType<T> = Promise<T> | RSVP.Promise<T>;
-
-interface Thenable<T, Return extends PromiseType<T>> {
-  then(resolve: (value: T) => T, reject?: (error: Error) => T): Return;
-}
-
 /**
- * A convenient utility function to simplify waiting for a promise. Can be used
- * in both decorator and function form, and the function form either accepts a
- * promise or an async function.
+ * A convenient utility function to simplify waiting for a promise.
  *
  * @public
  * @param promise {Promise<T> | RSVP.Promise<T>} The promise to track async operations for
@@ -32,104 +25,27 @@ interface Thenable<T, Return extends PromiseType<T>> {
  *     }));
  *   }
  * }
- *
- * @public
- * @param promise {Function} An async function
- * @param label {string} An optional string to identify the promise
- *
- * @example
- *
- * import Component from '@ember/component';
- * import { waitForPromise } from 'ember-test-waiters';
- *
- * export default Component.extend({
- *   doAsyncStuff: waitForPromise(async function doAsyncStuff() {
- *     await somethingAsync();
- *   }
- * });
- *
- * @example
- *
- * import Component from '@ember/component';
- * import { waitForPromise } from 'ember-test-waiters';
- *
- * export default class Friendz extends Component {
- *   @waitForPromise
- *   async doAsyncStuff() {
- *     await somethingAsync();
- *   }
- * }
- *
  */
-export default function waitForPromise(
-  target: object,
-  _key: string,
-  descriptor: PropertyDescriptor,
-  label?: string
-): PropertyDescriptor;
 export default function waitForPromise<T, KindOfPromise extends PromiseType<T>>(
   promise: KindOfPromise,
   label?: string
-): KindOfPromise;
-export default function waitForPromise<T, KindOfPromise extends PromiseType<T>>(
-  fn: Function,
-  label?: string
-): Function;
+): KindOfPromise {
+  let result = promise;
 
-export default function waitForPromise<T, KindOfPromise extends PromiseType<T>>(
-  ...args:
-    | [object, string, PropertyDescriptor, string?]
-    | [KindOfPromise, string?]
-    | [Function, string?]
-): PropertyDescriptor | KindOfPromise | Function {
-  let isFunctionalInvocation = args.length < 3;
+  if (DEBUG) {
+    PROMISE_WAITER.beginAsync(promise, label);
 
-  if (isFunctionalInvocation) {
-    let isArgumentPromise = (args[0] as KindOfPromise).then;
-
-    if (isArgumentPromise) {
-      let [promise, label] = args as [KindOfPromise, string?];
-      if (!DEBUG) {
-        return promise;
+    result = ((promise as unknown) as Thenable<T, KindOfPromise>).then(
+      (value: T) => {
+        PROMISE_WAITER.endAsync(promise);
+        return value;
+      },
+      (error: Error) => {
+        PROMISE_WAITER.endAsync(promise);
+        throw error;
       }
-
-      return wait(promise, label);
-    } else {
-      // argument is async function
-      let [fn, label] = args as [Function, string?];
-      if (!DEBUG) {
-        return fn;
-      }
-
-      return function(this: any, ...args: any[]) {
-        let promise = fn.call(this, ...args);
-        return wait(promise, label);
-      };
-    }
-  } else {
-    let [, , descriptor, label] = args as [object, string, PropertyDescriptor, string];
-    if (DEBUG) {
-      let fn = descriptor.value;
-      descriptor.value = function(...args: any[]) {
-        let promise = fn.call(this, ...args);
-        return wait(promise, label);
-      };
-    }
-    return descriptor;
+    );
   }
-}
 
-function wait<T, KindOfPromise extends PromiseType<T>>(promise: KindOfPromise, label?: string) {
-  PROMISE_WAITER.beginAsync(promise, label);
-
-  return ((promise as unknown) as Thenable<T, KindOfPromise>).then(
-    (value: T) => {
-      PROMISE_WAITER.endAsync(promise);
-      return value;
-    },
-    (error: Error) => {
-      PROMISE_WAITER.endAsync(promise);
-      throw error;
-    }
-  );
+  return result;
 }

--- a/addon/ember-test-waiters/wait-for-promise.ts
+++ b/addon/ember-test-waiters/wait-for-promise.ts
@@ -11,7 +11,9 @@ interface Thenable<T, Return extends PromiseType<T>> {
 }
 
 /**
- * A convenient utility function to simplify waiting for a promise.
+ * A convenient utility function to simplify waiting for a promise. Can be used
+ * in both decorator and function form, and the function form either accepts a
+ * promise or an async function.
  *
  * @public
  * @param promise {Promise<T> | RSVP.Promise<T>} The promise to track async operations for
@@ -30,27 +32,104 @@ interface Thenable<T, Return extends PromiseType<T>> {
  *     }));
  *   }
  * }
+ *
+ * @public
+ * @param promise {Function} An async function
+ * @param label {string} An optional string to identify the promise
+ *
+ * @example
+ *
+ * import Component from '@ember/component';
+ * import { waitForPromise } from 'ember-test-waiters';
+ *
+ * export default Component.extend({
+ *   doAsyncStuff: waitForPromise(async function doAsyncStuff() {
+ *     await somethingAsync();
+ *   }
+ * });
+ *
+ * @example
+ *
+ * import Component from '@ember/component';
+ * import { waitForPromise } from 'ember-test-waiters';
+ *
+ * export default class Friendz extends Component {
+ *   @waitForPromise
+ *   async doAsyncStuff() {
+ *     await somethingAsync();
+ *   }
+ * }
+ *
  */
+export default function waitForPromise(
+  target: object,
+  _key: string,
+  descriptor: PropertyDescriptor,
+  label?: string
+): PropertyDescriptor;
 export default function waitForPromise<T, KindOfPromise extends PromiseType<T>>(
   promise: KindOfPromise,
   label?: string
-): KindOfPromise {
-  let result = promise;
+): KindOfPromise;
+export default function waitForPromise<T, KindOfPromise extends PromiseType<T>>(
+  fn: Function,
+  label?: string
+): Function;
 
-  if (DEBUG) {
-    PROMISE_WAITER.beginAsync(promise, label);
+export default function waitForPromise<T, KindOfPromise extends PromiseType<T>>(
+  ...args:
+    | [object, string, PropertyDescriptor, string?]
+    | [KindOfPromise, string?]
+    | [Function, string?]
+): PropertyDescriptor | KindOfPromise | Function {
+  let isFunctionalInvocation = args.length < 3;
 
-    result = ((promise as unknown) as Thenable<T, KindOfPromise>).then(
-      (value: T) => {
-        PROMISE_WAITER.endAsync(promise);
-        return value;
-      },
-      (error: Error) => {
-        PROMISE_WAITER.endAsync(promise);
-        throw error;
+  if (isFunctionalInvocation) {
+    let isArgumentPromise = (args[0] as KindOfPromise).then;
+
+    if (isArgumentPromise) {
+      let [promise, label] = args as [KindOfPromise, string?];
+      if (!DEBUG) {
+        return promise;
       }
-    );
-  }
 
-  return result;
+      return wait(promise, label);
+    } else {
+      // argument is async function
+      let [fn, label] = args as [Function, string?];
+      if (!DEBUG) {
+        return fn;
+      }
+
+      return function(this: any, ...args: any[]) {
+        let promise = fn.call(this, ...args);
+        return wait(promise, label);
+      };
+    }
+  } else {
+    let [, , descriptor, label] = args as [object, string, PropertyDescriptor, string];
+    if (DEBUG) {
+      let fn = descriptor.value;
+      descriptor.value = function(...args: any[]) {
+        let promise = fn.call(this, ...args);
+        return wait(promise, label);
+      };
+    }
+    return descriptor;
+  }
+}
+
+function wait<T, KindOfPromise extends PromiseType<T>>(promise: KindOfPromise, label?: string) {
+  PROMISE_WAITER.beginAsync(promise, label);
+
+  return ((promise as unknown) as Thenable<T, KindOfPromise>).then(
+    (value: T) => {
+      PROMISE_WAITER.endAsync(promise);
+      return value;
+    },
+    (error: Error) => {
+      PROMISE_WAITER.endAsync(promise);
+      throw error;
+    }
+  );
 }

--- a/addon/ember-test-waiters/wait-for.ts
+++ b/addon/ember-test-waiters/wait-for.ts
@@ -1,0 +1,100 @@
+import { DEBUG } from '@glimmer/env';
+import waitForPromise from './wait-for-promise';
+
+type AsyncFunction<A extends Array<any>, PromiseReturn> = (...args: A) => Promise<PromiseReturn>;
+type AsyncFunctionArguments = [AsyncFunction<any[], any>, string?];
+type DecoratorArguments = [object, string, PropertyDescriptor, string?];
+
+/**
+ * A convenient utility function to simplify waiting for a promise. Can be used
+ * in both decorator and function form, and the function form either accepts a
+ * promise or an async function.
+ *
+ * @public
+ * @param promise {Promise<T> | RSVP.Promise<T>} The promise to track async operations for
+ * @param label {string} An optional string to identify the promise
+ *
+ * @example
+ *
+ * import Component from '@ember/component';
+ * import { waitForPromise } from '@ember/test-waiters';
+ *
+ * export default class Friendz extends Component {
+ *   didInsertElement() {
+ *     waitForPromise(new Promise(resolve => {
+ *       doSomeWork();
+ *       resolve();
+ *     }));
+ *   }
+ * }
+ *
+ * @public
+ * @param promise {Function} An async function
+ * @param label {string} An optional string to identify the promise
+ *
+ * @example
+ *
+ * import Component from '@ember/component';
+ * import { waitForPromise } from 'ember-test-waiters';
+ *
+ * export default Component.extend({
+ *   doAsyncStuff: waitForPromise(async function doAsyncStuff() {
+ *     await somethingAsync();
+ *   }
+ * });
+ *
+ * @example
+ *
+ * import Component from '@ember/component';
+ * import { waitForPromise } from 'ember-test-waiters';
+ *
+ * export default class Friendz extends Component {
+ *   @waitForPromise
+ *   async doAsyncStuff() {
+ *     await somethingAsync();
+ *   }
+ * }
+ *
+ */
+export default function waitFor(fn: AsyncFunction<any[], any>, label?: string): Function;
+export default function waitFor(
+  target: object,
+  _key: string,
+  descriptor: PropertyDescriptor,
+  label?: string
+): PropertyDescriptor;
+export default function waitFor(
+  ...args: AsyncFunctionArguments | DecoratorArguments
+): PropertyDescriptor | Function {
+  let isAsyncFunction = args.length < 3;
+
+  if (isAsyncFunction) {
+    // argument is async function
+    let [fn, label] = args as AsyncFunctionArguments;
+
+    if (!DEBUG) {
+      return fn;
+    }
+
+    return function(this: any, ...args: any[]) {
+      let promise = fn.call(this, ...args);
+
+      return waitForPromise(promise, label);
+    };
+  } else {
+    let [, , descriptor, label] = args as DecoratorArguments;
+
+    if (!DEBUG) {
+      return descriptor;
+    }
+
+    let fn = descriptor.value;
+
+    descriptor.value = function(...args: any[]) {
+      let promise = fn.call(this, ...args);
+      return waitForPromise(promise, label);
+    };
+
+    return descriptor;
+  }
+}

--- a/addon/ember-test-waiters/wait-for.ts
+++ b/addon/ember-test-waiters/wait-for.ts
@@ -6,27 +6,9 @@ type AsyncFunctionArguments = [AsyncFunction<any[], any>, string?];
 type DecoratorArguments = [object, string, PropertyDescriptor, string?];
 
 /**
- * A convenient utility function to simplify waiting for a promise. Can be used
- * in both decorator and function form, and the function form either accepts a
- * promise or an async function.
+ * A convenient utility function to simplify waiting for async. Can be used
+ * in both decorator and function form.
  *
- * @public
- * @param promise {Promise<T> | RSVP.Promise<T>} The promise to track async operations for
- * @param label {string} An optional string to identify the promise
- *
- * @example
- *
- * import Component from '@ember/component';
- * import { waitForPromise } from '@ember/test-waiters';
- *
- * export default class Friendz extends Component {
- *   didInsertElement() {
- *     waitForPromise(new Promise(resolve => {
- *       doSomeWork();
- *       resolve();
- *     }));
- *   }
- * }
  *
  * @public
  * @param promise {Function} An async function
@@ -35,10 +17,10 @@ type DecoratorArguments = [object, string, PropertyDescriptor, string?];
  * @example
  *
  * import Component from '@ember/component';
- * import { waitForPromise } from 'ember-test-waiters';
+ * import { waitFor } from 'ember-test-waiters';
  *
  * export default Component.extend({
- *   doAsyncStuff: waitForPromise(async function doAsyncStuff() {
+ *   doAsyncStuff: waitFor(async function doAsyncStuff() {
  *     await somethingAsync();
  *   }
  * });
@@ -46,10 +28,10 @@ type DecoratorArguments = [object, string, PropertyDescriptor, string?];
  * @example
  *
  * import Component from '@ember/component';
- * import { waitForPromise } from 'ember-test-waiters';
+ * import { waitFor } from 'ember-test-waiters';
  *
  * export default class Friendz extends Component {
- *   @waitForPromise
+ *   @waitFor
  *   async doAsyncStuff() {
  *     await somethingAsync();
  *   }
@@ -69,7 +51,6 @@ export default function waitFor(
   let isAsyncFunction = args.length < 3;
 
   if (isAsyncFunction) {
-    // argument is async function
     let [fn, label] = args as AsyncFunctionArguments;
 
     if (!DEBUG) {

--- a/tests/unit/wait-for-test.ts
+++ b/tests/unit/wait-for-test.ts
@@ -1,0 +1,143 @@
+import MockStableError, { overrideError, resetError } from './utils/mock-stable-error';
+import { _reset, getPendingWaiterState, waitFor } from 'ember-test-waiters';
+import { module, test } from 'qunit';
+
+import EmberObject from '@ember/object';
+import { DEBUG } from '@glimmer/env';
+import RSVP from 'rsvp';
+
+import { PromiseType, Thenable } from 'ember-test-waiters/types';
+
+interface PromiseClassType<T> {
+  new (resolve: (value: T) => T, ...args: any[]): PromiseType<T>;
+}
+
+interface PromiseDef {
+  name: string;
+  PromiseClass: PromiseClassType<any>;
+}
+
+interface ModeDef {
+  name: string;
+  createPromise: Function;
+  createThrowingPromise: Function;
+}
+
+if (DEBUG) {
+  module('wait-for', function(hooks) {
+    hooks.afterEach(function() {
+      _reset();
+      resetError();
+    });
+
+    // We want to ensure we test against both RSVP and Native promises
+    const promiseImpls: PromiseDef[] = [
+      { name: 'Native Promise', PromiseClass: Promise },
+      { name: 'RSVP.Promise', PromiseClass: RSVP.Promise },
+    ];
+
+    promiseImpls.forEach(({ name, PromiseClass }: PromiseDef) => {
+      module(name, function() {
+        class EmberObjectThing extends EmberObject.extend({
+          doAsyncStuff: waitFor(async function doAsyncStuff(...args: any) {
+            await new PromiseClass(resolve => {
+              setTimeout(resolve, 10);
+            });
+            return Array.from(args).reverse();
+          }),
+
+          asyncThrow: waitFor(async function asyncThrow() {
+            await new PromiseClass(resolve => {
+              setTimeout(resolve, 10);
+            });
+            throw new Error('doh!');
+          }),
+        }) {}
+
+        class NativeThing {
+          @waitFor
+          async doAsyncStuff(...args: any) {
+            await new PromiseClass(resolve => {
+              setTimeout(resolve, 10);
+            });
+            return Array.from(args).reverse();
+          }
+
+          @waitFor
+          async asyncThrow() {
+            await new PromiseClass(resolve => {
+              setTimeout(resolve, 10);
+            });
+            throw new Error('doh!');
+          }
+        }
+
+        const modes = [
+          {
+            // call an EmberObject class function that is wrapped in waitFor()
+            name: 'class function',
+            createPromise(...args: any[]) {
+              return EmberObjectThing.create().doAsyncStuff(...args);
+            },
+            createThrowingPromise() {
+              return EmberObjectThing.create().asyncThrow();
+            },
+          },
+          {
+            // call a native class function that is decorated with @waitFor
+            name: 'decorator',
+            createPromise(...args: any[]) {
+              return new NativeThing().doAsyncStuff(...args);
+            },
+            createThrowingPromise() {
+              return new NativeThing().asyncThrow();
+            },
+          },
+        ];
+
+        modes.forEach(({ name, createPromise, createThrowingPromise }: ModeDef) => {
+          module(name, function() {
+            test('waitFor wraps and registers a waiter', async function(assert) {
+              overrideError(MockStableError);
+
+              let promise = createPromise();
+
+              assert.deepEqual(getPendingWaiterState(), {
+                pending: 1,
+                waiters: {
+                  'ember-test-waiters:promise-waiter': [
+                    {
+                      label: undefined,
+                      stack: 'STACK',
+                    },
+                  ],
+                },
+              });
+
+              await ((promise as unknown) as Thenable<void, PromiseType<void>>).then(() => {
+                assert.deepEqual(getPendingWaiterState(), { pending: 0, waiters: {} });
+              });
+            });
+
+            test('waitFor handles arguments and return value', async function(assert) {
+              overrideError(MockStableError);
+
+              let ret = await createPromise(1, 'foo');
+              assert.deepEqual(ret, ['foo', 1]);
+            });
+
+            test('waitFor transitions waiter to not pending even if promise throws when thenable wrapped', async function(assert) {
+              let promise = createThrowingPromise();
+
+              try {
+                await promise;
+              } catch (e) {
+                assert.deepEqual(getPendingWaiterState(), { pending: 0, waiters: {} });
+              }
+            });
+          });
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
Extracted from #81 

A couple of notes:
* I have not address https://github.com/emberjs/ember-test-waiters/pull/81#discussion_r353930902 because I'm still a typescript noob and a jsdoc noob (so noob squared here)
* I had to do some interesting acrobatics to keep the `waitForPromise` tests reasonably DRY -- I'm definitely open to other ideas if anyone has any