### PR TITLE
Switch to using `ember-cli-version-checker` for gathering addons

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,7 @@ module.exports = {
       },
       plugins: ['node'],
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
-        // add your custom rules and overrides for node files here
+        'node/no-unpublished-require': 'off',
       }),
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,9 +41,7 @@ module.exports = {
         node: true,
       },
       plugins: ['node'],
-      rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
-        'node/no-unpublished-require': 'off',
-      }),
+      extends: ['plugin:node/recommended'],
     },
     {
       files: ['tests/**/*.[jt]s'],

--- a/force-highlander-addon.js
+++ b/force-highlander-addon.js
@@ -1,17 +1,6 @@
 'use strict';
 const semver = require('semver');
-
-function discoverAddons(addon, testWaiterAddons) {
-  let testWaiterAddon = addon.addons.find(addon => addon.name === 'ember-test-waiters');
-
-  if (testWaiterAddon) {
-    testWaiterAddons.push(testWaiterAddon);
-  }
-
-  addon.addons.forEach(addon => discoverAddons(addon, testWaiterAddons));
-
-  return testWaiterAddons;
-}
+const VersionChecker = require('ember-cli-version-checker');
 
 function findLatestVersion(addons) {
   let latestVersion = addons[0];
@@ -26,7 +15,8 @@ function findLatestVersion(addons) {
 }
 
 function forceHighlander(project) {
-  let testWaiterAddons = discoverAddons(project, []);
+  let checker = VersionChecker.forProject(project);
+  let testWaiterAddons = checker.filterAddonsByName('ember-test-waiters');
   let latestVersion = findLatestVersion(testWaiterAddons);
   let noop = () => {};
 
@@ -45,7 +35,6 @@ function forceHighlander(project) {
 }
 
 module.exports = {
-  discoverAddons,
   findLatestVersion,
   forceHighlander,
 };

--- a/node-tests/force-highlander-addon-test.js
+++ b/node-tests/force-highlander-addon-test.js
@@ -1,4 +1,5 @@
 const QUnit = require('qunit');
+const VersionChecker = require('ember-cli-version-checker');
 const highlander = require('../force-highlander-addon');
 
 const test = QUnit.test;
@@ -94,14 +95,9 @@ QUnit.module('force-highlander-addon', function(hooks) {
     };
   });
 
-  test('discoverAddons can discover all test waiter addons', function(assert) {
-    let addons = highlander.discoverAddons(this.project, []);
-
-    assert.equal(addons.length, 4);
-  });
-
   test('findLatestVersion can find the latest version from the set', function(assert) {
-    let addons = highlander.discoverAddons(this.project, []);
+    let checker = VersionChecker.forProject(this.project);
+    let addons = checker.filterAddonsByName('ember-test-waiters');
     let latestVersion = highlander.findLatestVersion(addons);
 
     assert.equal(latestVersion.pkg.version, '3.0.1');

--- a/node-tests/force-highlander-addon-test.js
+++ b/node-tests/force-highlander-addon-test.js
@@ -10,6 +10,8 @@ QUnit.module('force-highlander-addon', function(hooks) {
     this.project = {
       name: 'ember-top-level-package',
       pkg: { version: '1.0.0' },
+      isEmberCLIProject() {},
+      _addonsInitialized: true,
       addons: [
         {
           name: 'baz',

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ember-cli-test-loader": "^3.0.0",
     "ember-cli-typescript-blueprints": "^3.0.0",
     "ember-cli-uglify": "^3.0.0",
+    "ember-cli-version-checker": "^5.1.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "ember-cli-babel": "^7.18.0",
     "ember-cli-typescript": "^3.1.3",
+    "ember-cli-version-checker": "^5.1.0",
     "semver": "^7.1.3"
   },
   "devDependencies": {
@@ -48,7 +49,6 @@
     "ember-cli-test-loader": "^3.0.0",
     "ember-cli-typescript-blueprints": "^3.0.0",
     "ember-cli-uglify": "^3.0.0",
-    "ember-cli-version-checker": "^5.1.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3996,6 +3996,15 @@ ember-cli-version-checker@^4.1.0:
     semver "^6.3.0"
     silent-error "^1.1.1"
 
+ember-cli-version-checker@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-5.1.0.tgz#a3e92986397a87ce8e0540ed74e7c87b3ecd568e"
+  integrity sha512-DzK4OIgYGaETBNFzlhqdK7/ywRuQZjgiRa/NxQApL8OGoRaaHQPn4p49iJeGJG5vmZTR8KOwX3BnQO1ZqdIUig==
+  dependencies:
+    resolve-package-path "^2.0.0"
+    semver "^7.3.2"
+    silent-error "^1.1.1"
+
 ember-cli@~3.16.0:
   version "3.16.0"
   resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-3.16.0.tgz#5e96795c80166ab35d094584c216475a081a0123"
@@ -8511,6 +8520,11 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semve
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
 send@0.17.1:
   version "0.17.1"


### PR DESCRIPTION
Removes the use of a custom recursive search for discovering all addons in favor of using `ember-cli-version-checker`.