### PR TITLE
docs: fix install instructions to use proper pkg name

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This addon implements the design specified in [RFC 581](https://github.com/ember
 ## Installation
 
 ```
-ember install @ember/test-waiters
+ember install ember-test-waiters
 ```
 
 ## Quickstart


### PR DESCRIPTION
The installation instructions in the readme use the module name (`@ember/test-waiters`), but the package is published as `ember-test-waiters`.