### PR TITLE
Update highlander logic to be compatible with `ember-engines`

### DIFF
--- a/force-highlander-addon.js
+++ b/force-highlander-addon.js
@@ -29,7 +29,14 @@ function forceHighlander(project) {
         return;
       }
 
-      addon.treeFor = noop;
+      addon.cacheKeyForTree = (...args) => {
+        return latestVersion.cacheKeyForTree(...args);
+      };
+
+      addon.treeFor = (...args) => {
+        return latestVersion.treeFor(...args);
+      };
+
       addon.included = noop;
 
       return addon;

--- a/index.js
+++ b/index.js
@@ -1,13 +1,15 @@
 'use strict';
 
-const forceHighlander = require('./force-highlander-addon').forceHighlander;
+const { cacheKeyForStableTree: cacheKeyForTree } = require('calculate-cache-key-for-tree');
+const { forceHighlander } = require('./force-highlander-addon');
 
 module.exports = {
   name: require('./package').name,
 
+  cacheKeyForTree,
+
   included() {
     this._super.included.apply(this, arguments);
-
     forceHighlander(this.project);
   },
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:prod": "ember test --environment=production"
   },
   "dependencies": {
+    "calculate-cache-key-for-tree": "^2.0.0",
     "ember-cli-babel": "^7.21.0",
     "ember-cli-typescript": "^3.1.4",
     "ember-cli-version-checker": "^5.1.1",


### PR DESCRIPTION
The highlander logic in `@ember/test-waiters` is incompatible w/ `ember-engines`; this PR updates the logic to be compatible, while still maintaining the current highlander logic (latest version wins).

The rough failing scenario prior to these changes is as follows:

- When serving an engine, the engine acts as the project and the engine also is added as a dependency to the project by `ember-cli`. This basically means that if `@ember/test-waiters` is a dependency of the project, you'll get **two** instances of `@ember/test-waiters`.
- `ember-engines` has logic to decide whether an addon should be included in the actual engine being built (not the project); it does this based on a few things, but one of them being whether `@ember/test-waiters` is a dependency of the host. (Note: this logic in `ember-engines` is not specific to `@ember/test-waiters`; I'm just using it as an example in this scenario to illustrate the issue.)
- Because the current highlander logic in `@ember/test-waiters` no-ops all non-latest versions, we can't guarantee which of these two versions will be no-op'd (they both correspond to the _same_ version).

The end result is that this can get you in a scenario where `ember-engines` expects `@ember/test-waiters` to be provided by the host, but `@ember/test-waiters`'s highlanger logic has no-op'd the wrong version. In this case, `@ember/test-waiters` will never be bundled into the project (or engine), and will cause runtime dependency issues.

This PR updates the highlander logic in `@ember/test-waiters` to monkey patch all non-latest `@ember/test-waiters`, `ember-test-waiters` instances to use the latest `treeFor`, and `cacheKeyForTree` methods.