### PR TITLE
Ensure prereleases are used when present.

### DIFF
--- a/node-tests/force-highlander-addon-test.js
+++ b/node-tests/force-highlander-addon-test.js
@@ -109,6 +109,22 @@ const STABLE_FUNCTION_REF = () => {};
       assert.equal(latestVersion.pkg.version, '3.0.1');
     });
 
+    test('findLatestVersion can find beta versions', function(assert) {
+      let addons = [
+        {
+          name: 'foo',
+          pkg: { version: '1.0.0' },
+        },
+        {
+          name: 'foo',
+          pkg: { version: '1.1.0-beta.1' },
+        },
+      ];
+      let latestVersion = highlander.findLatestVersion(addons);
+
+      assert.equal(latestVersion.pkg.version, '1.1.0-beta.1');
+    });
+
     test('forceHighlander nullifies non-latest version addon methods', function(assert) {
       let testWaiterAddons = highlander.forceHighlander(this.project);
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ember-cli-babel": "^7.21.0",
     "ember-cli-typescript": "^3.1.4",
     "ember-cli-version-checker": "^5.1.1",
-    "semver": "^7.1.3"
+    "semver": "^7.3.2"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11648,7 +11648,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.3.2, semver@^7.0.0, semver@^7.1.3, semver@^7.3.2:
+semver@7.3.2, semver@^7.0.0, semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==


### PR DESCRIPTION
- Update to latest `semver`
- Add test confirming future version prerelease are accounted for.
