### PR TITLE
Fix IE11 compatiblity

### DIFF
--- a/addon/@ember/test-waiters/build-waiter.ts
+++ b/addon/@ember/test-waiters/build-waiter.ts
@@ -66,7 +66,13 @@ class TestWaiterImpl<T extends object | Primitive = Token> implements TestWaiter
   }
 
   debugInfo(): TestWaiterDebugInfo[] {
-    return [...this.items.values()];
+    let result: TestWaiterDebugInfo[] = [];
+
+    this.items.forEach(value => {
+      result.push(value);
+    });
+
+    return result;
   }
 
   reset(): void {

--- a/addon/@ember/test-waiters/waiter-manager.ts
+++ b/addon/@ember/test-waiters/waiter-manager.ts
@@ -44,7 +44,13 @@ export function unregister(waiter: Waiter): void {
  * @returns {Waiter[]}
  */
 export function getWaiters(): Waiter[] {
-  return [...WAITERS.values()];
+  let result: Waiter[] = [];
+
+  WAITERS.forEach(value => {
+    result.push(value);
+  });
+
+  return result;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ember-cli-typescript-blueprints": "^3.0.0",
     "ember-cli-uglify": "^3.0.0",
     "ember-concurrency": "^1.3.0",
-    "ember-concurrency-decorators": "^2.0.1",
+    "ember-concurrency-decorators": "github:rwjblue/ember-concurrency-decorators#fix-ie11",
     "ember-concurrency-ts": "^0.2.0",
     "ember-decorators-polyfill": "^1.1.5",
     "ember-disable-prototype-extensions": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "ember-source": "~3.20.4",
     "ember-source-channel-url": "^2.0.1",
     "ember-try": "^1.4.0",
+    "es6-promise": "^4.2.8",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.12.0",
     "eslint-plugin-ember": "^7.8.1",

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,5 +1,12 @@
 import QUnit from 'qunit';
 import AbstractTestLoader from 'ember-cli-test-loader/test-support/index';
+import { polyfill } from 'es6-promise';
+
+// When running under IE11, our tests are transpiled to use `Promise` (due to
+// asyncToGenerator helper in Babel)
+if (typeof Promise === 'undefined') {
+  polyfill();
+}
 
 let moduleLoadFailures = [];
 

--- a/tests/unit/build-waiter-test.ts
+++ b/tests/unit/build-waiter-test.ts
@@ -64,16 +64,11 @@ module('build-waiter', function(hooks) {
   test('test waiters automatically register when beginAsync is invoked when no token provided', function(assert) {
     let waiter = buildWaiter('my-addon:my-waiter');
 
-    let token = waiter.beginAsync();
+    waiter.beginAsync();
 
     let registeredWaiters = getWaiters();
 
     assert.equal(registeredWaiters[0], waiter, 'The waiter is registered');
-    assert.deepEqual(
-      (registeredWaiters[0] as any).items.keys().next().value,
-      token,
-      'Waiter item is in items'
-    );
   });
 
   test('test waiters automatically register when beginAsync is invoked using a custom token', function(assert) {
@@ -85,11 +80,6 @@ module('build-waiter', function(hooks) {
     let registeredWaiters = getWaiters();
 
     assert.equal(registeredWaiters[0], waiter, 'The waiter is registered');
-    assert.deepEqual(
-      (registeredWaiters[0] as any).items.keys().next().value,
-      {},
-      'Waiter item is in items'
-    );
   });
 
   test('test waiters removes item from items map when endAsync is invoked', function(assert) {

--- a/tests/unit/wait-for-test.ts
+++ b/tests/unit/wait-for-test.ts
@@ -7,6 +7,10 @@ import { DEBUG } from '@glimmer/env';
 import RSVP from 'rsvp';
 
 import { task as taskFn, TaskGenerator, didCancel } from 'ember-concurrency';
+// type resolution is not working correctly due to usage of forked
+// (non-published) ember-concurrency-decorators remove this ts-ignore when
+// migrating back to mainline off the fork
+// @ts-ignore
 import { task as taskDec } from 'ember-concurrency-decorators';
 import { perform } from 'ember-concurrency-ts';
 // @ts-ignore

--- a/tests/unit/wait-for-test.ts
+++ b/tests/unit/wait-for-test.ts
@@ -47,7 +47,8 @@ if (DEBUG) {
           await new Promise(resolve => {
             setTimeout(resolve, 10);
           });
-          return Array.from(args).reverse();
+
+          return args.reverse();
         }),
 
         asyncThrow: waitFor(async function asyncThrow() {
@@ -64,7 +65,7 @@ if (DEBUG) {
           await new Promise(resolve => {
             setTimeout(resolve, 10);
           });
-          return Array.from(args).reverse();
+          return args.reverse();
         }
 
         @waitFor
@@ -91,7 +92,7 @@ if (DEBUG) {
               yield new Promise(resolve => {
                 setTimeout(resolve, 10);
               });
-              return Array.from(args).reverse();
+              return args.reverse();
             })
           ),
           doAsyncStuff(...args: any) {
@@ -120,7 +121,7 @@ if (DEBUG) {
             yield new Promise(resolve => {
               setTimeout(resolve, 10);
             });
-            return Array.from(args).reverse();
+            return args.reverse();
           }
           doAsyncStuff(...args: any) {
             return perform(get(this, 'doStuffTask'), ...args);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5975,10 +5975,9 @@ ember-compatibility-helpers@^1.2.0:
     ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
 
-ember-concurrency-decorators@^2.0.1:
+"ember-concurrency-decorators@github:rwjblue/ember-concurrency-decorators#fix-ie11":
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ember-concurrency-decorators/-/ember-concurrency-decorators-2.0.1.tgz#f5465785e6cf44684fb158ae6ab3aa1b131fae43"
-  integrity sha512-KJ8mCZxmvgalawh/zytURsc5ParNr9avPeCDR/mE7VQxWvITHtyAuYS2s1PPFQAQggTXTZYcGnfgzjn/cDHNMQ==
+  resolved "https://codeload.github.com/rwjblue/ember-concurrency-decorators/tar.gz/5bdbf76b71f609358d08252f18e1195f3ecf8c3d"
   dependencies:
     "@ember-decorators/utils" "^6.1.0"
     ember-cli-babel "^7.19.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6305,7 +6305,7 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es6-promise@^4.0.3:
+es6-promise@^4.0.3, es6-promise@^4.2.8:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
   integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==


### PR DESCRIPTION
- Avoid usage of `Set.prototype.values` for IE11 compatiblity.
- [tests] Ensure a global `Promise` is present (for transpiled async/await)
- [tests] Remove syntax from tests that is unsupported in IE11
- [tests] Use fork of ember-concurrency-decorators to fix IE11 compat.

