### PR TITLE
update `cacheKeyForTree` override to account for both addon names

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,31 @@
 'use strict';
 
-const { cacheKeyForStableTree: cacheKeyForTree } = require('calculate-cache-key-for-tree');
+const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 const { forceHighlander } = require('./force-highlander-addon');
 
 module.exports = {
   name: require('./package').name,
 
-  cacheKeyForTree,
+  /**
+   * Returns a stable cache key with the addon name appended
+   *
+   * Because this addon eventually forces highlander for both `@ember/test-waiters`
+   * and `ember-test-waiters` we need to append the addon's name here; the end result
+   * is that we get a different stable cache key, one for `@ember/test-waiters` and
+   * another for `ember-test-waiters`
+   *
+   * The reason for this is that Embroider doesn't currently take into account the addon's
+   * name when dealing with cache keys internally & as a result, it gets confused that
+   * (seemingly) two different addons have the same cache key. This will eventually be fixed
+   * in Embroider, but in the short-term we're implementing this here to account for this issue.
+   *
+   * @name cacheKeyForTree
+   * @param {string} treeType
+   * @returns {string} the stable cache key
+   */
+  cacheKeyForTree(treeType) {
+    return `${calculateCacheKeyForTree(treeType, this)}-${this.name}`;
+  },
 
   included() {
     this._super.included.apply(this, arguments);


### PR DESCRIPTION
This updates the `cacheKeyForTree` override to account for both addon names (ie, `@ember/test-waiters` and `ember-test-waiters`).

The reason for this is that Embroider doesn't currently take into account the addon's name when dealing with cache keys internally & as a result, it gets confused that (seemingly) two different addons have the same cache key. This will eventually be fixed in Embroider, but in the short-term we're implementing this here to account for this issue.

The end result is that we get a different stable cache key, one for `@ember/test-waiters` and another for `ember-test-waiters`.