### PR TITLE
Fix potentially massive memory leak

### DIFF
--- a/addon/@ember/test-waiters/build-waiter.ts
+++ b/addon/@ember/test-waiters/build-waiter.ts
@@ -89,9 +89,11 @@ class TestWaiterImpl<T extends object | Primitive = Token> implements TestWaiter
   private _getCompletedOperations(token: T) {
     let type = typeof token;
 
-    return token !== null || (type !== 'function' && type !== 'object')
-      ? this.completedOperationsForPrimitives
-      : this.completedOperationsForTokens;
+    let isFunction = type === 'function';
+    let isObject = token !== null && type === 'object';
+    let isPrimitive = !isFunction && !isObject;
+
+    return isPrimitive ? this.completedOperationsForPrimitives : this.completedOperationsForTokens;
   }
 }
 

--- a/tests/unit/build-waiter-test.ts
+++ b/tests/unit/build-waiter-test.ts
@@ -276,4 +276,16 @@ module('build-waiter', function(hooks) {
 
     assert.equal((waiter as any).items.size, 0);
   });
+
+  test('completed operations tracking does not leak non-primitive tokens', function(assert) {
+    let waiter = buildWaiter('@ember/test-waiters:my-waiter');
+
+    const tokens = [undefined, {}, function() {}, Promise.resolve()];
+
+    for (let token of tokens) {
+      waiter.endAsync(waiter.beginAsync(token));
+    }
+
+    assert.equal((waiter as any).completedOperationsForPrimitives.size, 0);
+  });
 });


### PR DESCRIPTION
The logic for choosing between the Map and WeakMap for completed operation tracking wasn't right, and the result was that everything was being added to the Map, leaking every token. For waitForPromise() the token is the promise itself, meaning the resolved values were also leaking, which can easily add up to a memory leak of epic proportions.