### PR TITLE
Broken type imports leak into Javascript

### DIFF
--- a/addon/@ember/test-waiters/build-waiter.ts
+++ b/addon/@ember/test-waiters/build-waiter.ts
@@ -68,7 +68,7 @@ class TestWaiterImpl<T extends object | Primitive = Token> implements TestWaiter
   debugInfo(): TestWaiterDebugInfo[] {
     let result: TestWaiterDebugInfo[] = [];
 
-    this.items.forEach(value => {
+    this.items.forEach((value) => {
       result.push(value);
     });
 

--- a/addon/@ember/test-waiters/index.ts
+++ b/addon/@ember/test-waiters/index.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   WaiterName,
   Token,
   Primitive,

--- a/addon/@ember/test-waiters/wait-for.ts
+++ b/addon/@ember/test-waiters/wait-for.ts
@@ -115,7 +115,7 @@ function wrapFunction(fn: Function, label?: string) {
     return fn;
   }
 
-  return function(this: any, ...args: any[]) {
+  return function (this: any, ...args: any[]) {
     let result = fn.call(this, ...args);
 
     if (isThenable(result)) {

--- a/addon/@ember/test-waiters/waiter-manager.ts
+++ b/addon/@ember/test-waiters/waiter-manager.ts
@@ -46,7 +46,7 @@ export function unregister(waiter: Waiter): void {
 export function getWaiters(): Waiter[] {
   let result: Waiter[] = [];
 
-  WAITERS.forEach(value => {
+  WAITERS.forEach((value) => {
     result.push(value);
   });
 
@@ -80,7 +80,7 @@ export function getPendingWaiterState(): PendingWaiterState {
     waiters: {},
   };
 
-  WAITERS.forEach(waiter => {
+  WAITERS.forEach((waiter) => {
     if (!waiter.waitUntil()) {
       result.pending++;
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,12 +2,12 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-module.exports = function() {
+module.exports = function () {
   return Promise.all([
     getChannelURL('release'),
     getChannelURL('beta'),
     getChannelURL('canary'),
-  ]).then(urls => {
+  ]).then((urls) => {
     return {
       useYarn: true,
       scenarios: [

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,5 +1,5 @@
 'use strict';
 
-module.exports = function(/* environment, appConfig */) {
+module.exports = function (/* environment, appConfig */) {
   return {};
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -2,7 +2,7 @@
 
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
-module.exports = function(defaults) {
+module.exports = function (defaults) {
   let app = new EmberAddon(defaults, {
     autoImport: {
       exclude: ['qunit'],

--- a/force-highlander-addon.js
+++ b/force-highlander-addon.js
@@ -6,7 +6,7 @@ const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 function findLatestVersion(addons) {
   let latestVersion = addons[0];
 
-  addons.forEach(addon => {
+  addons.forEach((addon) => {
     if (semver.gt(addon.pkg.version, latestVersion.pkg.version)) {
       latestVersion = addon;
     }
@@ -25,12 +25,12 @@ function forceHighlander(project) {
   let noop = () => {};
 
   return testWaiterAddons
-    .map(addon => {
+    .map((addon) => {
       if (addon === latestVersion) {
         return;
       }
 
-      addon.cacheKeyForTree = treeType => {
+      addon.cacheKeyForTree = (treeType) => {
         // because this is overriding _both_ `@ember/test-waiters` and `ember-test-waiters`
         // we need to append the addon's name here; the end result is that we get a different
         // stable cache key, one for `@ember/test-waiters` and another for `ember-test-waiters`

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = {
       We're intentionally not calling super here in order to correctly output
       multiple modules (@ember/test-helpers and ember-test-helpers).
     */
-    let babel = this.addons.find(a => a.name === 'ember-cli-babel');
+    let babel = this.addons.find((a) => a.name === 'ember-cli-babel');
 
     return babel.transpileTree(tree);
   },

--- a/node-tests/force-highlander-addon-test.js
+++ b/node-tests/force-highlander-addon-test.js
@@ -8,9 +8,9 @@ const addonIndex = require('../index');
 const test = QUnit.test;
 const STABLE_FUNCTION_REF = () => {};
 
-['ember-test-waiters', '@ember/test-waiters'].forEach(moduleName => {
-  QUnit.module(`force-highlander-addon for ${moduleName}`, function(hooks) {
-    hooks.beforeEach(function() {
+['ember-test-waiters', '@ember/test-waiters'].forEach((moduleName) => {
+  QUnit.module(`force-highlander-addon for ${moduleName}`, function (hooks) {
+    hooks.beforeEach(function () {
       this.project = {
         name: 'ember-top-level-package',
         pkg: { version: '1.0.0' },
@@ -106,7 +106,7 @@ const STABLE_FUNCTION_REF = () => {};
       };
     });
 
-    test('findLatestVersion can find the latest version from the set', function(assert) {
+    test('findLatestVersion can find the latest version from the set', function (assert) {
       let checker = VersionChecker.forProject(this.project);
       let addons = [
         ...checker.filterAddonsByName('ember-test-waiters'),
@@ -117,7 +117,7 @@ const STABLE_FUNCTION_REF = () => {};
       assert.equal(latestVersion.pkg.version, '3.0.1');
     });
 
-    test('findLatestVersion can find beta versions', function(assert) {
+    test('findLatestVersion can find beta versions', function (assert) {
       let addons = [
         {
           name: 'foo',
@@ -133,17 +133,17 @@ const STABLE_FUNCTION_REF = () => {};
       assert.equal(latestVersion.pkg.version, '1.1.0-beta.1');
     });
 
-    test('forceHighlander nullifies non-latest addon `included` methods', function(assert) {
+    test('forceHighlander nullifies non-latest addon `included` methods', function (assert) {
       let testWaiterAddons = highlander.forceHighlander(this.project);
 
       assert.equal(testWaiterAddons.length, 3);
 
-      testWaiterAddons.forEach(addon => {
+      testWaiterAddons.forEach((addon) => {
         assert.notEqual(addon.included, STABLE_FUNCTION_REF);
       });
     });
 
-    test('forceHighlander monkey patches non-latest w/ latest `treeFor`', function(assert) {
+    test('forceHighlander monkey patches non-latest w/ latest `treeFor`', function (assert) {
       let checker = VersionChecker.forProject(this.project);
       let addons = [
         ...checker.filterAddonsByName('ember-test-waiters'),
@@ -159,7 +159,7 @@ const STABLE_FUNCTION_REF = () => {};
 
       assert.equal(nonLatestTestWaiterAddons.length, 3);
 
-      nonLatestTestWaiterAddons.forEach(addon => {
+      nonLatestTestWaiterAddons.forEach((addon) => {
         assert.notEqual(addon.treeFor, STABLE_FUNCTION_REF);
         assert.notEqual(addon.cacheKeyForTree, STABLE_FUNCTION_REF);
 
@@ -173,7 +173,7 @@ const STABLE_FUNCTION_REF = () => {};
       );
     });
 
-    test('forceHighlander returns stable cache keys for each addon (`@ember/test-waiters` and `ember-test-waiters`)', function(assert) {
+    test('forceHighlander returns stable cache keys for each addon (`@ember/test-waiters` and `ember-test-waiters`)', function (assert) {
       const AddonCtor = Addon.extend({
         ...addonIndex,
         root: path.resolve(__dirname, '..'),
@@ -199,7 +199,7 @@ const STABLE_FUNCTION_REF = () => {};
 
       assert.equal(nonLatestTestWaiterAddons.length, 4);
 
-      nonLatestTestWaiterAddons.forEach(addon => {
+      nonLatestTestWaiterAddons.forEach((addon) => {
         assert.ok(addon.cacheKeyForTree().endsWith(moduleName));
 
         assert.strictEqual(

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.3.1",
     "loader.js": "^4.7.0",
-    "prettier": "^1.19.1",
+    "prettier": "^2",
     "qunit": "^2.13.0",
     "release-it": "^14.2.2",
     "release-it-lerna-changelog": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "dependencies": {
     "calculate-cache-key-for-tree": "^2.0.0",
-    "ember-cli-babel": "^7.21.0",
-    "ember-cli-typescript": "^3.1.4",
+    "ember-cli-babel": "^7.23.1",
+    "ember-cli-typescript": "^4.1.0",
     "ember-cli-version-checker": "^5.1.2",
     "semver": "^7.3.2"
   },

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -6,6 +6,6 @@ const Router = EmberRouter.extend({
   rootURL: config.rootURL,
 });
 
-Router.map(function() {});
+Router.map(function () {});
 
 export default Router;

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function(environment) {
+module.exports = function (environment) {
   let ENV = {
     modulePrefix: 'dummy',
     environment,

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -10,7 +10,7 @@ if (typeof Promise === 'undefined') {
 
 let moduleLoadFailures = [];
 
-QUnit.done(function() {
+QUnit.done(function () {
   if (moduleLoadFailures.length) {
     throw new Error('\n' + moduleLoadFailures.join('\n'));
   }
@@ -21,7 +21,7 @@ class TestLoader extends AbstractTestLoader {
     moduleLoadFailures.push(error);
 
     QUnit.module('TestLoader Failures');
-    QUnit.test(moduleName + ': could not be loaded', function() {
+    QUnit.test(moduleName + ': could not be loaded', function () {
       throw error;
     });
   }
@@ -29,7 +29,7 @@ class TestLoader extends AbstractTestLoader {
 
 new TestLoader().loadModules();
 
-QUnit.testDone(function() {
+QUnit.testDone(function () {
   let testElementContainer = document.getElementById('ember-testing-container');
   let testElementReset = testElementContainer.outerHTML;
   testElementContainer.innerHTML = testElementReset;

--- a/tests/unit/build-waiter-test.ts
+++ b/tests/unit/build-waiter-test.ts
@@ -12,29 +12,29 @@ import { Promise } from 'rsvp';
 import Token from '@ember/test-waiters/token';
 import { registerWarnHandler } from '@ember/debug';
 
-module('build-waiter', function(hooks) {
-  hooks.afterEach(function() {
+module('build-waiter', function (hooks) {
+  hooks.afterEach(function () {
     _reset();
     _resetWaiterNames();
     resetError();
     registerWarnHandler(() => {});
   });
 
-  test('test waiter can be instantiated with a namespace only', function(assert) {
+  test('test waiter can be instantiated with a namespace only', function (assert) {
     let name = 'my-addon';
     let waiter = buildWaiter(name);
 
     assert.equal(waiter.name, name);
   });
 
-  test('test waiter can be instantiated with a namespace and descriptor', function(assert) {
+  test('test waiter can be instantiated with a namespace and descriptor', function (assert) {
     let name = 'my-addon:my-waiter';
     let waiter = buildWaiter(name);
 
     assert.equal(waiter.name, name);
   });
 
-  test('test waiters will warn when waiter name is used more than once', function(assert) {
+  test('test waiters will warn when waiter name is used more than once', function (assert) {
     registerWarnHandler((message, options) => {
       console.log('message', message);
       assert.equal(message, "The waiter name '@ember/test-waiters:first' is already in use");
@@ -45,7 +45,7 @@ module('build-waiter', function(hooks) {
     buildWaiter('@ember/test-waiters:first');
   });
 
-  test('test waiters return a token from beginAsync when no token provided', function(assert) {
+  test('test waiters return a token from beginAsync when no token provided', function (assert) {
     let waiter = buildWaiter('my-addon:my-waiter');
 
     let token = waiter.beginAsync();
@@ -53,7 +53,7 @@ module('build-waiter', function(hooks) {
     assert.ok(token instanceof Token, 'A token was returned from beginAsync');
   });
 
-  test('test waiters return a truthy token from beginAsync when no token provided', function(assert) {
+  test('test waiters return a truthy token from beginAsync when no token provided', function (assert) {
     let waiter = buildWaiter('my-addon:my-waiter');
 
     let token = waiter.beginAsync();
@@ -61,7 +61,7 @@ module('build-waiter', function(hooks) {
     assert.ok(token, 'A token was returned from beginAsync and is truthy');
   });
 
-  test('test waiters automatically register when beginAsync is invoked when no token provided', function(assert) {
+  test('test waiters automatically register when beginAsync is invoked when no token provided', function (assert) {
     let waiter = buildWaiter('my-addon:my-waiter');
 
     waiter.beginAsync();
@@ -71,7 +71,7 @@ module('build-waiter', function(hooks) {
     assert.equal(registeredWaiters[0], waiter, 'The waiter is registered');
   });
 
-  test('test waiters automatically register when beginAsync is invoked using a custom token', function(assert) {
+  test('test waiters automatically register when beginAsync is invoked using a custom token', function (assert) {
     let waiter = buildWaiter('@ember/test-waiters:my-waiter');
     let waiterItem = {};
 
@@ -82,7 +82,7 @@ module('build-waiter', function(hooks) {
     assert.equal(registeredWaiters[0], waiter, 'The waiter is registered');
   });
 
-  test('test waiters removes item from items map when endAsync is invoked', function(assert) {
+  test('test waiters removes item from items map when endAsync is invoked', function (assert) {
     let waiter = buildWaiter('@ember/test-waiters:my-waiter');
 
     let token = waiter.beginAsync();
@@ -92,7 +92,7 @@ module('build-waiter', function(hooks) {
     assert.equal((registeredWaiters[0] as any).items.size, 0);
   });
 
-  test('test waiters removes item from items map when endAsync is invoked using a custom token', function(assert) {
+  test('test waiters removes item from items map when endAsync is invoked using a custom token', function (assert) {
     let waiter = buildWaiter('@ember/test-waiters:my-waiter');
     let waiterItem = {};
 
@@ -103,7 +103,7 @@ module('build-waiter', function(hooks) {
     assert.equal((registeredWaiters[0] as any).items.size, 0);
   });
 
-  test('beginAsync will throw if a prior call to beginAsync with the same token occurred', function(assert) {
+  test('beginAsync will throw if a prior call to beginAsync with the same token occurred', function (assert) {
     let waiter = buildWaiter('@ember/test-waiters:my-waiter');
 
     assert.throws(
@@ -116,7 +116,7 @@ module('build-waiter', function(hooks) {
     );
   });
 
-  test('beginAsync will throw if a prior call to beginAsync with the same token occurred', function(assert) {
+  test('beginAsync will throw if a prior call to beginAsync with the same token occurred', function (assert) {
     let waiter = buildWaiter('@ember/test-waiters:my-waiter');
     let token = {};
 
@@ -130,7 +130,7 @@ module('build-waiter', function(hooks) {
     );
   });
 
-  test('endAsync will throw if a prior call to beginAsync with the same token did not occur', function(assert) {
+  test('endAsync will throw if a prior call to beginAsync with the same token did not occur', function (assert) {
     let waiter = buildWaiter('@ember/test-waiters:my-waiter');
     let token = 0;
 
@@ -143,7 +143,7 @@ module('build-waiter', function(hooks) {
     );
   });
 
-  test('endAsync will throw if a prior call to beginAsync with the same token did not occur using custom token', function(assert) {
+  test('endAsync will throw if a prior call to beginAsync with the same token did not occur using custom token', function (assert) {
     let waiter = buildWaiter('@ember/test-waiters:my-waiter');
     let waiterItem = {};
 
@@ -156,7 +156,7 @@ module('build-waiter', function(hooks) {
     );
   });
 
-  test('endAsync will not throw if endAsync called twice in a row with the same token', function(assert) {
+  test('endAsync will not throw if endAsync called twice in a row with the same token', function (assert) {
     assert.expect(0);
 
     let waiter = buildWaiter('@ember/test-waiters:my-waiter');
@@ -166,7 +166,7 @@ module('build-waiter', function(hooks) {
     waiter.endAsync(token);
   });
 
-  test('endAsync will not throw if endAsync called twice in a row with the same token using custom token', function(assert) {
+  test('endAsync will not throw if endAsync called twice in a row with the same token using custom token', function (assert) {
     assert.expect(0);
 
     let waiter = buildWaiter('@ember/test-waiters:my-waiter');
@@ -177,7 +177,7 @@ module('build-waiter', function(hooks) {
     waiter.endAsync(waiterItem);
   });
 
-  test('waitUntil returns the correct value if the waiter should wait', function(assert) {
+  test('waitUntil returns the correct value if the waiter should wait', function (assert) {
     let waiter = buildWaiter('@ember/test-waiters:my-waiter');
     let waiterItem = {};
 
@@ -192,7 +192,7 @@ module('build-waiter', function(hooks) {
     assert.ok(waiter.waitUntil(), 'waitUntil returns true');
   });
 
-  test('waiter contains debug info for a waiter item', function(assert) {
+  test('waiter contains debug info for a waiter item', function (assert) {
     let waiter = buildWaiter('@ember/test-waiters:my-waiter');
     let waiterItem = {};
 
@@ -203,7 +203,7 @@ module('build-waiter', function(hooks) {
     assert.deepEqual(waiter.debugInfo(), [{ label: undefined, stack: 'STACK' }]);
   });
 
-  test('waiter executes beginAsync and endAsync at the correct times in relation to thenables', async function(assert) {
+  test('waiter executes beginAsync and endAsync at the correct times in relation to thenables', async function (assert) {
     const promiseWaiter = buildWaiter('@ember/test-waiters:promise-waiter');
     function waitForPromise<T>(promise: Promise<T>, label?: string) {
       let result = promise;
@@ -212,12 +212,12 @@ module('build-waiter', function(hooks) {
       promiseWaiter.beginAsync(promise, label);
 
       result = promise.then(
-        value => {
+        (value) => {
           assert.step('Waiter ended async tracking');
           promiseWaiter.endAsync(promise);
           return value;
         },
-        error => {
+        (error) => {
           promiseWaiter.endAsync(promise);
           throw error;
         }
@@ -226,7 +226,7 @@ module('build-waiter', function(hooks) {
       return result;
     }
 
-    let promise: Promise<{}> = new Promise(resolve => {
+    let promise: Promise<{}> = new Promise((resolve) => {
       assert.step('Promise resolving');
       resolve();
     });
@@ -265,7 +265,7 @@ module('build-waiter', function(hooks) {
     ]);
   });
 
-  test('waiter can clear items', function(assert) {
+  test('waiter can clear items', function (assert) {
     let waiter = buildWaiter('@ember/test-waiters:my-waiter');
 
     waiter.beginAsync();
@@ -277,10 +277,10 @@ module('build-waiter', function(hooks) {
     assert.equal((waiter as any).items.size, 0);
   });
 
-  test('completed operations tracking does not leak non-primitive tokens', function(assert) {
+  test('completed operations tracking does not leak non-primitive tokens', function (assert) {
     let waiter = buildWaiter('@ember/test-waiters:my-waiter');
 
-    const tokens = [undefined, {}, function() {}, Promise.resolve()];
+    const tokens = [undefined, {}, function () {}, Promise.resolve()];
 
     for (let token of tokens) {
       waiter.endAsync(waiter.beginAsync(token));

--- a/tests/unit/import-legacy-module-test.ts
+++ b/tests/unit/import-legacy-module-test.ts
@@ -3,13 +3,13 @@ import { module, test } from 'qunit';
 
 import { resetError } from './utils/mock-stable-error';
 
-module('import-legacy-module', function(hooks) {
-  hooks.afterEach(function() {
+module('import-legacy-module', function (hooks) {
+  hooks.afterEach(function () {
     _reset();
     resetError();
   });
 
-  test('test waiter can be instantiated with a name', function(assert) {
+  test('test waiter can be instantiated with a name', function (assert) {
     let name = 'my-waiter';
     let waiter = buildWaiter(name);
 

--- a/tests/unit/wait-for-promise-test.ts
+++ b/tests/unit/wait-for-promise-test.ts
@@ -6,20 +6,20 @@ import { DEBUG } from '@glimmer/env';
 import RSVP from 'rsvp';
 
 if (DEBUG) {
-  module('wait-for-promise', function(hooks) {
-    hooks.afterEach(function() {
+  module('wait-for-promise', function (hooks) {
+    hooks.afterEach(function () {
       _reset();
       resetError();
     });
 
-    module(`Implementation: Native Promise`, function() {
-      hooks.afterEach(function() {
+    module(`Implementation: Native Promise`, function () {
+      hooks.afterEach(function () {
         _reset();
         resetError();
       });
 
-      test('waitForPromise wraps and registers a waiter', async function(assert) {
-        let promise = new Promise(resolve => {
+      test('waitForPromise wraps and registers a waiter', async function (assert) {
+        let promise = new Promise((resolve) => {
           resolve();
         });
 
@@ -44,7 +44,7 @@ if (DEBUG) {
         });
       });
 
-      test('waitForPromise transitions waiter to not pending even if promise throws', async function(assert) {
+      test('waitForPromise transitions waiter to not pending even if promise throws', async function (assert) {
         let promise = Promise.resolve().then(() => {
           throw new Error('Promise threw');
         });
@@ -56,7 +56,7 @@ if (DEBUG) {
         }
       });
 
-      test('waitForPromise transitions waiter to not pending even if promise throws when thenable wrapped', async function(assert) {
+      test('waitForPromise transitions waiter to not pending even if promise throws when thenable wrapped', async function (assert) {
         let promise = Promise.resolve().then(() => {
           throw new Error('Promise threw');
         });
@@ -69,14 +69,14 @@ if (DEBUG) {
       });
     });
 
-    module(`Implementation: RSVP.Promise`, function() {
-      hooks.afterEach(function() {
+    module(`Implementation: RSVP.Promise`, function () {
+      hooks.afterEach(function () {
         _reset();
         resetError();
       });
 
-      test('waitForPromise wraps and registers a waiter', async function(assert) {
-        let promise = new RSVP.Promise(resolve => {
+      test('waitForPromise wraps and registers a waiter', async function (assert) {
+        let promise = new RSVP.Promise((resolve) => {
           resolve();
         });
 
@@ -101,7 +101,7 @@ if (DEBUG) {
         });
       });
 
-      test('waitForPromise transitions waiter to not pending even if promise throws', async function(assert) {
+      test('waitForPromise transitions waiter to not pending even if promise throws', async function (assert) {
         let promise = RSVP.Promise.resolve().then(() => {
           throw new Error('Promise threw');
         });
@@ -113,7 +113,7 @@ if (DEBUG) {
         }
       });
 
-      test('waitForPromise transitions waiter to not pending even if promise throws when thenable wrapped', async function(assert) {
+      test('waitForPromise transitions waiter to not pending even if promise throws when thenable wrapped', async function (assert) {
         let promise = RSVP.Promise.resolve().then(() => {
           throw new Error('Promise threw');
         });

--- a/tests/unit/wait-for-test.ts
+++ b/tests/unit/wait-for-test.ts
@@ -34,8 +34,8 @@ interface ModeDef {
 }
 
 if (DEBUG) {
-  module('wait-for', function(hooks) {
-    hooks.afterEach(function() {
+  module('wait-for', function (hooks) {
+    hooks.afterEach(function () {
       _reset();
       resetError();
     });
@@ -48,7 +48,7 @@ if (DEBUG) {
     const promiseTestModules = promiseImplementations.map(({ name, Promise }) => {
       class EmberObjectThing extends EmberObject.extend({
         doAsyncStuff: waitFor(async function doAsyncStuff(...args: any) {
-          await new Promise(resolve => {
+          await new Promise((resolve) => {
             setTimeout(resolve, 10);
           });
 
@@ -56,7 +56,7 @@ if (DEBUG) {
         }),
 
         asyncThrow: waitFor(async function asyncThrow() {
-          await new Promise(resolve => {
+          await new Promise((resolve) => {
             setTimeout(resolve, 10);
           });
           throw new Error('doh!');
@@ -66,7 +66,7 @@ if (DEBUG) {
       class NativeThing {
         @waitFor
         async doAsyncStuff(...args: any) {
-          await new Promise(resolve => {
+          await new Promise((resolve) => {
             setTimeout(resolve, 10);
           });
           return args.reverse();
@@ -74,7 +74,7 @@ if (DEBUG) {
 
         @waitFor
         async asyncThrow() {
-          await new Promise(resolve => {
+          await new Promise((resolve) => {
             setTimeout(resolve, 10);
           });
           throw new Error('doh!');
@@ -89,11 +89,11 @@ if (DEBUG) {
     });
 
     const generatorTestModules = [
-      (function() {
+      (function () {
         const EmberObjectThing = EmberObject.extend({
           doStuffTask: taskFn(
             waitFor(function* doTaskStuff(...args: any) {
-              yield new Promise(resolve => {
+              yield new Promise((resolve) => {
                 setTimeout(resolve, 10);
               });
               return args.reverse();
@@ -106,7 +106,7 @@ if (DEBUG) {
 
           throwingTask: taskFn(
             waitFor(function* taskThrow() {
-              yield new Promise(resolve => {
+              yield new Promise((resolve) => {
                 setTimeout(resolve, 10);
               });
               throw new Error('doh!');
@@ -122,7 +122,7 @@ if (DEBUG) {
           @taskDec
           @waitFor
           *doStuffTask(...args: any): TaskGenerator<any[]> {
-            yield new Promise(resolve => {
+            yield new Promise((resolve) => {
               setTimeout(resolve, 10);
             });
             return args.reverse();
@@ -134,7 +134,7 @@ if (DEBUG) {
           @taskDec
           @waitFor
           *throwingTask() {
-            yield new Promise(resolve => {
+            yield new Promise((resolve) => {
               setTimeout(resolve, 10);
             });
             throw new Error('doh!');
@@ -155,7 +155,7 @@ if (DEBUG) {
     const testModules = [...promiseTestModules, ...generatorTestModules];
 
     testModules.forEach(({ name, waiterName, EmberObjectThing, NativeThing }) => {
-      module(name, function() {
+      module(name, function () {
         const invocationType = [
           {
             name: 'class function',
@@ -178,8 +178,8 @@ if (DEBUG) {
         ];
 
         invocationType.forEach(({ name, createPromise, createThrowingPromise }: ModeDef) => {
-          module(name, function() {
-            test('waitFor wraps and registers a waiter', async function(assert) {
+          module(name, function () {
+            test('waitFor wraps and registers a waiter', async function (assert) {
               overrideError(MockStableError);
 
               let promise = createPromise();
@@ -201,14 +201,14 @@ if (DEBUG) {
               });
             });
 
-            test('waitFor handles arguments and return value', async function(assert) {
+            test('waitFor handles arguments and return value', async function (assert) {
               overrideError(MockStableError);
 
               let ret = await createPromise(1, 'foo');
               assert.deepEqual(ret, ['foo', 1]);
             });
 
-            test('waitFor transitions waiter to not pending even if promise throws when thenable wrapped', async function(assert) {
+            test('waitFor transitions waiter to not pending even if promise throws when thenable wrapped', async function (assert) {
               let promise = createThrowingPromise();
 
               try {
@@ -222,13 +222,13 @@ if (DEBUG) {
       });
     });
 
-    module('waitFor ember-concurrency interop', function() {
+    module('waitFor ember-concurrency interop', function () {
       class Deferred {
         promise: Promise<any>;
         resolve: Function = () => null;
 
         constructor() {
-          this.promise = new Promise(res => (this.resolve = res));
+          this.promise = new Promise((res) => (this.resolve = res));
         }
       }
 
@@ -262,7 +262,7 @@ if (DEBUG) {
         }
       }
 
-      test('tasks with multiple yields work', async function(assert) {
+      test('tasks with multiple yields work', async function (assert) {
         let thing = new NativeThing();
 
         let promise = perform(get(thing, 'doStuffTask'));
@@ -296,7 +296,7 @@ if (DEBUG) {
       ];
 
       cancellationCases.forEach(({ desc, taskName }) => {
-        test(`${desc} task cancellation works`, async function(assert) {
+        test(`${desc} task cancellation works`, async function (assert) {
           let thing = new NativeThing();
 
           let instance = perform(get(thing, taskName));
@@ -319,7 +319,7 @@ if (DEBUG) {
       });
     });
 
-    module('waitFor co interop', function() {
+    module('waitFor co interop', function () {
       function coDec(
         _target: object,
         _key: string,
@@ -334,7 +334,7 @@ if (DEBUG) {
         resolve: Function = () => null;
 
         constructor() {
-          this.promise = new Promise(res => (this.resolve = res));
+          this.promise = new Promise((res) => (this.resolve = res));
         }
       }
 
@@ -355,7 +355,7 @@ if (DEBUG) {
         }
       }
 
-      test('it works', async function(assert) {
+      test('it works', async function (assert) {
         let thing = new NativeThing();
 
         let promise = thing.doStuffCo();

--- a/tests/unit/waiter-manager-noop-test.ts
+++ b/tests/unit/waiter-manager-noop-test.ts
@@ -4,12 +4,12 @@ import { module, test } from 'qunit';
 import { DEBUG } from '@glimmer/env';
 
 if (!DEBUG) {
-  module('waiter-manager-noop | DEBUG: false', function(hooks) {
-    hooks.afterEach(function() {
+  module('waiter-manager-noop | DEBUG: false', function (hooks) {
+    hooks.afterEach(function () {
       _reset();
     });
 
-    test('buildWaiter returns NoopTestWaiter DEBUG: false', function(assert) {
+    test('buildWaiter returns NoopTestWaiter DEBUG: false', function (assert) {
       let waiter = buildWaiter('first');
 
       assert.equal(
@@ -19,16 +19,16 @@ if (!DEBUG) {
       );
     });
 
-    test('register will correctly add a waiter', function(assert) {
+    test('register will correctly add a waiter', function (assert) {
       let waiter = buildWaiter('@ember/test-waiters:first');
 
       register(waiter);
 
-      let waiters = getWaiters().map(w => w.name);
+      let waiters = getWaiters().map((w) => w.name);
       assert.deepEqual(waiters, ['@ember/test-waiters:first']);
     });
 
-    test('a NoopTestWaiter always returns true from waitUntil', function(assert) {
+    test('a NoopTestWaiter always returns true from waitUntil', function (assert) {
       let waiter = buildWaiter('@ember/test-waiters:first');
 
       assert.ok(waiter.waitUntil(), 'waitUntil returns true');
@@ -38,7 +38,7 @@ if (!DEBUG) {
       assert.ok(waiter.waitUntil(), 'waitUntil returns true');
     });
 
-    test('a NoopTestWaiter always returns true from waitUntil', function(assert) {
+    test('a NoopTestWaiter always returns true from waitUntil', function (assert) {
       let waiter = buildWaiter('@ember/test-waiters:first');
       let waiterItem = {};
 

--- a/tests/unit/waiter-manager-test.ts
+++ b/tests/unit/waiter-manager-test.ts
@@ -17,8 +17,8 @@ import { DEBUG } from '@glimmer/env';
 import { registerWarnHandler } from '@ember/debug';
 
 if (DEBUG) {
-  module('waiter-manager | DEBUG: true', function(hooks) {
-    hooks.afterEach(function() {
+  module('waiter-manager | DEBUG: true', function (hooks) {
+    hooks.afterEach(function () {
       _reset();
       _resetWaiterNames();
       resetError();
@@ -26,41 +26,41 @@ if (DEBUG) {
       registerWarnHandler(() => {});
     });
 
-    test('register will correctly add a waiter', function(assert) {
+    test('register will correctly add a waiter', function (assert) {
       let waiter = buildWaiter('@ember/test-waiters:first');
 
       register(waiter);
 
-      let waiters = getWaiters().map(w => w.name);
+      let waiters = getWaiters().map((w) => w.name);
       assert.deepEqual(waiters, ['@ember/test-waiters:first']);
     });
 
-    test('register will only add one waiter with the same name', function(assert) {
+    test('register will only add one waiter with the same name', function (assert) {
       let waiter = buildWaiter('@ember/test-waiters:first');
       let secondWaiterButStillCalledFirst = buildWaiter('@ember/test-waiters:first');
 
       register(waiter);
       register(secondWaiterButStillCalledFirst);
 
-      let waiters = getWaiters().map(w => w.name);
+      let waiters = getWaiters().map((w) => w.name);
       assert.deepEqual(waiters, ['@ember/test-waiters:first']);
     });
 
-    test('unregister will correctly remove a waiter', function(assert) {
+    test('unregister will correctly remove a waiter', function (assert) {
       let waiter = buildWaiter('@ember/test-waiters:first');
 
       register(waiter);
 
-      let waiters = getWaiters().map(w => w.name);
+      let waiters = getWaiters().map((w) => w.name);
       assert.deepEqual(waiters, ['@ember/test-waiters:first'], 'precond');
 
       unregister(waiter);
 
-      waiters = getWaiters().map(w => w.name);
+      waiters = getWaiters().map((w) => w.name);
       assert.deepEqual(waiters, [], 'precond');
     });
 
-    test('getWaiters returns all registered waiters', function(assert) {
+    test('getWaiters returns all registered waiters', function (assert) {
       let waiter = buildWaiter('@ember/test-waiters:first');
 
       assert.equal(getWaiters(), 0, 'No waiters are registered');
@@ -74,7 +74,7 @@ if (DEBUG) {
       assert.equal(getWaiters(), 0, 'No waiters are registered');
     });
 
-    test('getPendingWaiterState returns information on pending waiters', function(assert) {
+    test('getPendingWaiterState returns information on pending waiters', function (assert) {
       let first = buildWaiter('@ember/test-waiters:first');
       let second = buildWaiter('@ember/test-waiters:second');
       let firstItem = {};
@@ -127,7 +127,7 @@ if (DEBUG) {
       assert.deepEqual(getPendingWaiterState().waiters, {}, 'No waiters are pending');
     });
 
-    test('getPendingWaiterState contains label info when label provided', function(assert) {
+    test('getPendingWaiterState contains label info when label provided', function (assert) {
       let first = buildWaiter('@ember/test-waiters:first');
       let second = buildWaiter('@ember/test-waiters:second');
       let firstItem = {};
@@ -157,7 +157,7 @@ if (DEBUG) {
       });
     });
 
-    test('hasPendingWaiters can check if waiting is required', function(assert) {
+    test('hasPendingWaiters can check if waiting is required', function (assert) {
       let first = buildWaiter('@ember/test-waiters:first');
       let second = buildWaiter('@ember/test-waiters:second');
       let firstItem = {};
@@ -178,7 +178,7 @@ if (DEBUG) {
       assert.strictEqual(hasPendingWaiters(), false, 'Second waiter is not pending');
     });
 
-    test('custom waiters can be registered', function(assert) {
+    test('custom waiters can be registered', function (assert) {
       let customWaiterCounter = 0;
       let customWaiter;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3003,6 +3003,13 @@ babel-plugin-ember-modules-api-polyfill@^3.2.0:
   dependencies:
     ember-rfc176-data "^0.3.16"
 
+babel-plugin-ember-modules-api-polyfill@^3.2.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-3.4.0.tgz#3f5e0457e135f8a29b3a8b6910806bb5b524649e"
+  integrity sha512-nVu/LqbZBAup1zLij6xGvQwVLWVk4XYu2fl4vIOUR3S6ukdonMLhKAb0d4QXSzH30Pd7OczVTlPffWbiwahdJw==
+  dependencies:
+    ember-rfc176-data "^0.3.16"
+
 babel-plugin-filter-imports@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-4.0.0.tgz#068f8da15236a96a9602c36dc6f4a6eeca70a4f4"
@@ -5514,7 +5521,7 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.6.0:
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.7.3:
   version "7.23.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.23.0.tgz#ec580aa2c115d0810e454dd5c2fffce238284b92"
   integrity sha512-ix58DlRDAbGITtdJoRUPcAoQwKLYr/x/kIXjU9u1ATyhmuUjqb+0FDXghOWbkNihGiNOqBBR49+LBgK9AeBcNw==
@@ -5533,6 +5540,38 @@ ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cl
     babel-plugin-debug-macros "^0.3.3"
     babel-plugin-ember-data-packages-polyfill "^0.1.2"
     babel-plugin-ember-modules-api-polyfill "^3.2.0"
+    babel-plugin-module-resolver "^3.1.1"
+    broccoli-babel-transpiler "^7.8.0"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.1"
+    broccoli-source "^1.1.0"
+    clone "^2.1.2"
+    ember-cli-babel-plugin-helpers "^1.1.1"
+    ember-cli-version-checker "^4.1.0"
+    ensure-posix-path "^1.0.2"
+    fixturify-project "^1.10.0"
+    rimraf "^3.0.1"
+    semver "^5.5.0"
+
+ember-cli-babel@^7.23.1:
+  version "7.23.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.23.1.tgz#d1517228ede08a5d4b045c78a7429728e956b30b"
+  integrity sha512-qYggmt3hRs6QJ6cRkww3ahMpyP8IEV2KFrIRO/Z6hu9MkE/8Y28Xd5NjQl6fPV3oLoG0vwuHzhNe3Jr7Wec8zw==
+  dependencies:
+    "@babel/core" "^7.12.0"
+    "@babel/helper-compilation-targets" "^7.12.0"
+    "@babel/plugin-proposal-class-properties" "^7.10.4"
+    "@babel/plugin-proposal-decorators" "^7.10.5"
+    "@babel/plugin-transform-modules-amd" "^7.10.5"
+    "@babel/plugin-transform-runtime" "^7.12.0"
+    "@babel/plugin-transform-typescript" "^7.12.0"
+    "@babel/polyfill" "^7.11.5"
+    "@babel/preset-env" "^7.12.0"
+    "@babel/runtime" "^7.12.0"
+    amd-name-resolver "^1.2.1"
+    babel-plugin-debug-macros "^0.3.3"
+    babel-plugin-ember-data-packages-polyfill "^0.1.2"
+    babel-plugin-ember-modules-api-polyfill "^3.2.1"
     babel-plugin-module-resolver "^3.1.1"
     broccoli-babel-transpiler "^7.8.0"
     broccoli-debug "^0.6.4"
@@ -5727,6 +5766,22 @@ ember-cli-typescript@^3.1.4:
     semver "^6.3.0"
     stagehand "^1.0.0"
     walk-sync "^2.0.0"
+
+ember-cli-typescript@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-4.1.0.tgz#2ff17be2e6d26b58c88b1764cb73887e7176618b"
+  integrity sha512-zSuKG8IQuYE3vS+c7V0mHJqwrN/4Wo9Wr50+0NUjnZH3P99ChynczQHu/P7WSifkO6pF6jaxwzf09XzWvG8sVw==
+  dependencies:
+    ansi-to-html "^0.6.6"
+    broccoli-stew "^3.0.0"
+    debug "^4.0.0"
+    execa "^4.0.0"
+    fs-extra "^9.0.1"
+    resolve "^1.5.0"
+    rsvp "^4.8.1"
+    semver "^7.3.2"
+    stagehand "^1.0.0"
+    walk-sync "^2.2.0"
 
 ember-cli-uglify@^3.0.0:
   version "3.0.0"
@@ -6469,7 +6524,7 @@ exec-sh@^0.3.2:
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.4.tgz#3a018ceb526cc6f6df2bb504b2bfe8e3a4934ec5"
   integrity sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==
 
-execa@4.1.0, execa@^4.0.2, execa@^4.0.3, execa@^4.1.0:
+execa@4.1.0, execa@^4.0.0, execa@^4.0.2, execa@^4.0.3, execa@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
   integrity sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -10433,10 +10433,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 printf@^0.5.1:
   version "0.5.2"


### PR DESCRIPTION
The meat of this PR is the one line change in https://github.com/emberjs/ember-test-waiters/commit/31317db4c583977b63e4f5b0b1cf0777498a8f89.

To make that work though I had to upgrade prettier, which required me to reformat a lot of the repo, and upgrade ember-cli-typescript and ember-cli-babel to make sure we would get a new enough version of `@babel/plugin-transform-typescript` to handle type-only exports.

The motivation for this change is that without marking these are type-only exports, the export statement ends up staying in the Javascript even though the corresponding type definitions got deleted. That mismatch is a SyntaxError when you're using a system that respects ES modules.

