### PR TITLE
Fix warnings when the legacy module deprecation is triggered

### DIFF
--- a/addon/ember-test-waiters/index.ts
+++ b/addon/ember-test-waiters/index.ts
@@ -6,6 +6,8 @@ deprecate(
   {
     id: 'ember-test-waiters-legacy-module-name',
     until: '3.0.0',
+    for: 'ember-test-waiters',
+    since: '2.2.0',
   }
 );
 


### PR DESCRIPTION
```
DEPRECATION: When calling `deprecate` you must provide `for` in options. Missing options.for in \"ember-test-waiters-legacy-module-name\" deprecation [deprecation id: ember-source.deprecation-without-for]

DEPRECATION: When calling `deprecate` you must provide `since` in options. Missing options.since in \"ember-test-waiters-legacy-module-name\" deprecation [deprecation id: ember-source.deprecation-without-since]
```

This adds the required `for` and `since` options when creating the deprecation warning.