### PR TITLE
Updating .npmignore to remove unneeded files from publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -20,11 +20,15 @@
 /.template-lintrc.js
 /.watchmanconfig
 /config/ember-try.js
+/CHANGELOG.md
 /CONTRIBUTING.md
 /ember-cli-build.js
+/node-tests/
+/RELEASE.md
 /testem.js
 /tests/
-/node-tests/
+/tsconfig.json
+/vendor/
 /yarn-error.log
 /yarn.lock
 .gitkeep

--- a/.npmignore
+++ b/.npmignore
@@ -6,26 +6,29 @@
 /bower_components/
 
 # misc
-/.bowerrc
 /.editorconfig
 /.ember-cli
 /.env*
+/.eslintcache
 /.eslintignore
 /.eslintrc.js
+/.git/
+/.github
 /.gitignore
+/.prettierignore
+/.prettierrc.js
 /.template-lintrc.js
-/.travis.yml
 /.watchmanconfig
-/bower.json
 /config/ember-try.js
 /CONTRIBUTING.md
 /ember-cli-build.js
 /testem.js
 /tests/
+/node-tests/
+/yarn-error.log
 /yarn.lock
 .gitkeep
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
 /package.json.ember-try

--- a/.npmignore
+++ b/.npmignore
@@ -19,7 +19,7 @@
 /.prettierrc.js
 /.template-lintrc.js
 /.watchmanconfig
-/config/ember-try.js
+/config/
 /CHANGELOG.md
 /CONTRIBUTING.md
 /ember-cli-build.js


### PR DESCRIPTION
Our `.npmignore` was out of date, resulting in a number of extraneous files being published. This PR fixes that.

[fixes #291]