### PR TITLE
no longer fail fast on try-scenarios

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -32,7 +32,7 @@ jobs:
     needs: test
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         ember-try-scenario:
           - ember-lts-2.18


### PR DESCRIPTION
no longer fail fast on try-scenarios, as doing so makes it tedious to see what part of the build matrix passed and what part failed