### PR TITLE
Updates ember-try scenarios to work with ember-auto-import@2

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -95,6 +95,10 @@ module.exports = async function () {
       {
         name: 'ember-release',
         npm: {
+          dependencies: {
+            'ember-auto-import': '^2.2.0',
+            webpack: '^5.0.0',
+          },
           devDependencies: {
             'ember-source': await getChannelURL('release'),
           },
@@ -103,6 +107,10 @@ module.exports = async function () {
       {
         name: 'ember-beta',
         npm: {
+          dependencies: {
+            'ember-auto-import': '^2.2.0',
+            webpack: '^5.0.0',
+          },
           devDependencies: {
             'ember-source': await getChannelURL('beta'),
           },
@@ -111,6 +119,10 @@ module.exports = async function () {
       {
         name: 'ember-canary',
         npm: {
+          dependencies: {
+            'ember-auto-import': '^2.2.0',
+            webpack: '^5.0.0',
+          },
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
           },


### PR DESCRIPTION
The reason we're using this method instead of simply upgrading to ember-auto-import@2 is the latter requires an upgrade of our node `engines` support, which would be a breaking change.