### PR TITLE
Avoid unreachable code after return warning

### DIFF
--- a/addon/@ember/test-waiters/build-waiter.ts
+++ b/addon/@ember/test-waiters/build-waiter.ts
@@ -159,17 +159,17 @@ export default function buildWaiter(name: string): TestWaiter {
 
   if (!DEBUG) {
     return new NoopTestWaiter(name);
+  } else {
+    warn(
+      `You must provide a name that contains a descriptive prefix separated by a colon.
+  
+        Example: ember-fictitious-addon:some-file
+  
+        You passed: ${name}`,
+      WAITER_NAME_PATTERN.test(name),
+      { id: '@ember/test-waiters.invalid-waiter-name' }
+    );
+
+    return new TestWaiterImpl(name);
   }
-
-  warn(
-    `You must provide a name that contains a descriptive prefix separated by a colon.
-
-      Example: ember-fictitious-addon:some-file
-
-      You passed: ${name}`,
-    WAITER_NAME_PATTERN.test(name),
-    { id: '@ember/test-waiters.invalid-waiter-name' }
-  );
-
-  return new TestWaiterImpl(name);
 }


### PR DESCRIPTION
This code seems to be optimized by babel, uglify or similar into something like this:

```js
define("@ember/test-waiters/build-waiter", [ "exports", "@ember/debug", "@ember/test-waiters/token", "@ember/test-waiters/waiter-manager" ], (function(e, t, r, n) {
  "use strict";
  Object.defineProperty(e, "__esModule", {
    value: !0
  });
  e._resetWaiterNames = function() {
    a = new Set;
  };
  e.default = function(e) {
    0;
    return new l(e);
    return new s(e);
  };
  function i(e, t, r) {
    t in e ? Object.defineProperty(e, t, {
      value: r,
      enumerable: !0,
      configurable: !0,
      writable: !0
    }) : e[t] = r;
    return e;
  }
  let a;
  function o() {
    return new r.default;
  }
  class s {
    constructor(e, t) {
      i(this, "isRegistered", !1);
      i(this, "items", new Map);
      i(this, "completedOperationsForTokens", new WeakMap);
      i(this, "completedOperationsForPrimitives", new Map);
      this.name = e;
      this.nextToken = t || o;
    }
    beginAsync(e = this.nextToken(), t) {
      this._register();
      if (this.items.has(e)) throw new Error(`beginAsync called for ${e} but it is already pending.`);
      let r = new Error;
      this.items.set(e, {
        get stack() {
          return r.stack;
        },
        label: t
      });
      return e;
    }
    endAsync(e) {
      if (!this.items.has(e) && !this._getCompletedOperations(e).has(e)) throw new Error("endAsync called with no preceding beginAsync call.");
      this.items.delete(e);
      this._getCompletedOperations(e).set(e, !0);
    }
    waitUntil() {
      return 0 === this.items.size;
    }
    debugInfo() {
      let e = [];
      this.items.forEach((t => {
        e.push(t);
      }));
      return e;
    }
    reset() {
      this.items.clear();
    }
    _register() {
      if (!this.isRegistered) {
        (0, n.register)(this);
        this.isRegistered = !0;
      }
    }
    _getCompletedOperations(e) {
      let t = typeof e;
      return !("function" === t) && !(null !== e && "object" === t) ? this.completedOperationsForPrimitives : this.completedOperationsForTokens;
    }
  }
  class l {
    constructor(e) {
      this.name = e;
    }
    beginAsync() {
      return this;
    }
    endAsync() {}
    waitUntil() {
      return !0;
    }
    debugInfo() {
      return [];
    }
    reset() {}
  }
}));
```

The following lines generates an "Avoid unreachable code after return" warning in Chrome Developer Tools:

```js
    return new l(e);
    return new s(e);
```

![image](https://user-images.githubusercontent.com/122287/148933670-5e603fc4-c5d4-48d7-86ec-908e66e752a1.png)

Obviously harmless, but it creates noise.

Hopefully this adjustment will resolve it.