### PR TITLE
Moving ember-cli-typescript to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "calculate-cache-key-for-tree": "^2.0.0",
     "ember-cli-babel": "^7.26.6",
+    "ember-cli-typescript": "^4.2.1",
     "ember-cli-version-checker": "^5.1.2",
     "semver": "^7.3.5"
   },
@@ -62,7 +63,6 @@
     "ember-cli-htmlbars": "^5.7.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-test-loader": "^3.0.0",
-    "ember-cli-typescript": "^4.2.1",
     "ember-cli-typescript-blueprints": "^3.0.0",
     "ember-cli-uglify": "^3.0.0",
     "ember-concurrency": "^2.1.2",


### PR DESCRIPTION
As indicated by the package, this should be a dependency, not a devDep.