### PR TITLE
Ensure waiters are discovered even if multiple versions exist

### DIFF
--- a/addon/@ember/test-waiters/waiter-manager.ts
+++ b/addon/@ember/test-waiters/waiter-manager.ts
@@ -11,7 +11,7 @@ type Indexable = Record<any, unknown>;
 const WAITERS: Map<WaiterName, Waiter> = (function () {
   const HAS_SYMBOL = typeof Symbol !== 'undefined';
 
-  let symbolName = 'LIFELINE_QUEUED_POLL_TASKS';
+  let symbolName = 'TEST_WAITERS';
   let symbol = HAS_SYMBOL ? (Symbol.for(symbolName) as any) : symbolName;
 
   let global = getGlobal();


### PR DESCRIPTION
Currently, we rely heavily on the highlander logic to ensure that we can **only** ever have one version of `@ember/test-waiters` in the build outpu. The reason for this is so that when someone calls `hasPendingWaiters()` we can reliably ensure that _**ALL**_ waiters that have been registered (regardless of version mismatches and whatnot) are found.

Unfortunately, we cannot actually rely on the highlander logic to guarantee this "waiter map" uniqueness in Embroider builds (because the highlander logic is broken by the isolated nature of Embroiders compatibility layer).

This change migrates from a strict reliance on the highlander logic to guarantee the module scoped variable is shared globally to a mechanism of sharing the state on `globalThis` (with fallbacks for various other scenarios). Using this pattern allows us to avoid "caring" if the highlander code actually enforces a single version, while still ensuring that `hasPendingWaiters` will always return the right value.

It is likely that future changes will remove the usage of the highlander logic as of a certain version (that includes this change) and higher.
