### PR TITLE
Remove IE11 from targets as the browser is not supported anymore

### DIFF
--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -2,13 +2,6 @@
 
 const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
 
-const isCI = !!process.env.CI;
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };


### PR DESCRIPTION
Extracted from: https://github.com/emberjs/ember-test-waiters/pull/455
Goal: Get C.I. green with the fewest changes possible.

(all the other changes in my PRs do still need to be merged tho -- just want to make sure changes are targeted -- bigger PRs are split out and rebased as things get merged / discovered)