### PR TITLE
Move `WAITER_NAMES` to global context to reduce warning log spew when this addon becomes v2 and duplicates are allowed

### DIFF
--- a/addon/@ember/test-waiters/build-waiter.ts
+++ b/addon/@ember/test-waiters/build-waiter.ts
@@ -3,13 +3,33 @@ import { Primitive, TestWaiter, TestWaiterDebugInfo, WaiterName } from './';
 import { DEBUG } from '@glimmer/env';
 import { warn } from '@ember/debug';
 import Token from './token';
-import { register } from './waiter-manager';
+import { register, getPrivateData } from './waiter-manager';
 
 const WAITER_NAME_PATTERN = /^[^:]*:?.*/;
-let WAITER_NAMES = DEBUG ? new Set() : undefined;
+
+// NOTE: historically, we've only been able to allow one copy of test-waiters in a whole projcet.
+//       this was forced via build-time code in the v1-addon's index.js.
+//       This added maintenance complexity and prevented the conversion to a v2 addon.
+//
+//       With this runtime injection of global state, we can have both the pre-v2 addon
+//       and the v2 addon share the same waiter state.
+//       Also, in `@ember/test-waiters@v3`, we can force the existing build-time code to
+//       take precedecence with the latestVersion of test-waiters v3 (existing behavior),
+//       so there is no risk of old copies of test-waiters not using this runtime highlander code,
+//       because those older copies would not be present in the final build of an app.
+//
+// SAFETY: Types are statically defined,
+//         and we're creating dynamic data on the global scope.
+//         we don't want consumers to know about this data, so we don't
+//         want to extend the type ever. Casting to any is a fine tradeoff.
+getPrivateData().WAITER_NAMES ||= DEBUG ? new Set() : undefined;
+
+function getWaiters(): Set<string> {
+  return getPrivateData().WAITER_NAMES as Set<string>;
+}
 
 export function _resetWaiterNames() {
-  WAITER_NAMES = new Set();
+  getPrivateData().WAITER_NAMES = new Set();
 }
 
 function getNextToken(): Token {
@@ -156,10 +176,10 @@ class NoopTestWaiter implements TestWaiter {
  */
 export default function buildWaiter(name: string): TestWaiter {
   if (DEBUG) {
-    warn(`The waiter name '${name}' is already in use`, !WAITER_NAMES!.has(name), {
+    warn(`The waiter name '${name}' is already in use`, !getWaiters()!.has(name), {
       id: '@ember/test-waiters.duplicate-waiter-name',
     });
-    WAITER_NAMES!.add(name);
+    getWaiters()!.add(name);
   }
 
   if (!DEBUG) {

--- a/addon/@ember/test-waiters/index.ts
+++ b/addon/@ember/test-waiters/index.ts
@@ -15,8 +15,9 @@ export {
   _reset,
   getPendingWaiterState,
   hasPendingWaiters,
+  _resetWaiterNames,
 } from './waiter-manager';
 
-export { default as buildWaiter, _resetWaiterNames } from './build-waiter';
+export { default as buildWaiter } from './build-waiter';
 export { default as waitForPromise } from './wait-for-promise';
 export { default as waitFor } from './wait-for';

--- a/addon/@ember/test-waiters/waiter-manager.ts
+++ b/addon/@ember/test-waiters/waiter-manager.ts
@@ -20,7 +20,7 @@ assert(
 // - highlander code will run, and boot out the v2 addon copy
 // - v2 addon has precedence, and the min-version of test-waiters throughout the
 //   dep graph should not preceed the version which this symbol was introduced.
-const PRIVATE_GLOBAL_DATA_KEY = Symbol.for(`@ember/test-waiters' WAITERS`);
+const PRIVATE_GLOBAL_DATA_KEY = Symbol.for(`TEST_WAITERS`);
 
 // this ensures that if @ember/test-waiters exists in multiple places in the
 // build output we will still use a single map of waiters (there really should

--- a/addon/@ember/test-waiters/waiter-manager.ts
+++ b/addon/@ember/test-waiters/waiter-manager.ts
@@ -44,9 +44,6 @@ export function getPrivateData(): WaitersData {
 }
 
 type GlobalContext = Record<typeof PRIVATE_GLOBAL_DATA_KEY, WaitersData>;
-// interface GlobalContext {
-//   [typeof PRIVATE_GLOBAL_DATA_KEY]: WaitersData;
-// }
 
 interface WaitersData {
   WAITER_NAMES?: Set<string> | undefined;


### PR DESCRIPTION
NOTE: this PR will need to target to the `main` branch as well (which I plan on doing after all the test apps are implemented)

Context on "The Plan": https://github.com/emberjs/ember-test-waiters/issues/458

historically, we've only been able to allow one copy of test-waiters in a whole projcet.
this was forced via build-time code in the v1-addon's index.js.
This added maintenance complexity and prevented the conversion to a v2 addon.

With this runtime injection of global state, we can have both the pre-v2 addon
and the v2 addon share the same waiter state.
Also, in `@ember/test-waiters@v3`, we can force the existing build-time code to
take precedecence with the latestVersion of test-waiters v3 (existing behavior),
so there is no risk of old copies of test-waiters not using this runtime highlander code,
because those older copies would not be present in the final build of an app.

-------------

## So what does this PR actually _do_?

- Moves all module state to `globalThis`
  - `getGlobal` already existed, so much of this work was already done
  - the `WAITERS` have already been handled
  - this PR focuses on moving `WAITER_NAMES` to also be on the global context, so we don't create a ton of log spew.
- More specific types to its clearer what the shape of data is for each of these structures
  e.g.:
  ```js
  globalThis: {
    // existing
    [Symbol<'TEST_WAITERS'>]?: Map<WaiterName, Waiter> | undefined;
    // new!
    [Symbol<'TEST_WAITER_NAMES'>]?: Set<string> | undefined;
  }
  ```


-------

## NOTES

- declared compatibility of the 3.x series of this addon include Ember 3.8, which includes IE11 -- so we can't go full native Symbol support yet.
