### PR TITLE
Drop support for Typescript < 4.9

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -76,7 +76,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.5.1",
     "qunit": "^2.20.0",
-    "typescript": "~4.4.2",
+    "typescript": "~5.0.0",
     "webpack": "^5.0.0"
   },
   "engines": {

--- a/addon/package.json
+++ b/addon/package.json
@@ -76,7 +76,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.5.1",
     "qunit": "^2.20.0",
-    "typescript": "~5.0.0",
+    "typescript": "~4.9.0",
     "webpack": "^5.0.0"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,10 +71,10 @@ importers:
         version: 4.0.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^4.29.2
-        version: 4.33.0(@typescript-eslint/parser@4.33.0)(eslint@7.32.0)(typescript@5.0.4)
+        version: 4.33.0(@typescript-eslint/parser@4.33.0)(eslint@7.32.0)(typescript@4.9.5)
       '@typescript-eslint/parser':
         specifier: ^4.30.0
-        version: 4.33.0(eslint@7.32.0)(typescript@5.0.4)
+        version: 4.33.0(eslint@7.32.0)(typescript@4.9.5)
       co:
         specifier: ^4.6.0
         version: 4.6.0
@@ -154,8 +154,8 @@ importers:
         specifier: ^2.20.0
         version: 2.20.0
       typescript:
-        specifier: ~5.0.0
-        version: 5.0.4
+        specifier: ~4.9.0
+        version: 4.9.5
       webpack:
         specifier: ^5.0.0
         version: 5.88.2
@@ -6392,7 +6392,7 @@ packages:
       '@types/yargs-parser': 21.0.3
     dev: true
 
-  /@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0)(eslint@7.32.0)(typescript@5.0.4):
+  /@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0)(eslint@7.32.0)(typescript@4.9.5):
     resolution: {integrity: sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -6403,8 +6403,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.33.0(eslint@7.32.0)(typescript@5.0.4)
-      '@typescript-eslint/parser': 4.33.0(eslint@7.32.0)(typescript@5.0.4)
+      '@typescript-eslint/experimental-utils': 4.33.0(eslint@7.32.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 4.33.0(eslint@7.32.0)(typescript@4.9.5)
       '@typescript-eslint/scope-manager': 4.33.0
       debug: 4.3.4
       eslint: 7.32.0
@@ -6412,8 +6412,8 @@ packages:
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.5
-      tsutils: 3.21.0(typescript@5.0.4)
-      typescript: 5.0.4
+      tsutils: 3.21.0(typescript@4.9.5)
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6447,7 +6447,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils@4.33.0(eslint@7.32.0)(typescript@5.0.4):
+  /@typescript-eslint/experimental-utils@4.33.0(eslint@7.32.0)(typescript@4.9.5):
     resolution: {integrity: sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -6456,7 +6456,7 @@ packages:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
-      '@typescript-eslint/typescript-estree': 4.33.0(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 4.33.0(typescript@4.9.5)
       eslint: 7.32.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@7.32.0)
@@ -6465,7 +6465,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.0.4):
+  /@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@4.9.5):
     resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -6477,10 +6477,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
-      '@typescript-eslint/typescript-estree': 4.33.0(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 4.33.0(typescript@4.9.5)
       debug: 4.3.4
       eslint: 7.32.0
-      typescript: 5.0.4
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6552,7 +6552,7 @@ packages:
     engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@4.33.0(typescript@5.0.4):
+  /@typescript-eslint/typescript-estree@4.33.0(typescript@4.9.5):
     resolution: {integrity: sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -6567,8 +6567,8 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.5
-      tsutils: 3.21.0(typescript@5.0.4)
-      typescript: 5.0.4
+      tsutils: 3.21.0(typescript@4.9.5)
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -17812,14 +17812,14 @@ packages:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: true
 
-  /tsutils@3.21.0(typescript@5.0.4):
+  /tsutils@3.21.0(typescript@4.9.5):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.0.4
+      typescript: 4.9.5
     dev: true
 
   /type-check@0.4.0:
@@ -17870,9 +17870,9 @@ packages:
     resolution: {integrity: sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==}
     dev: true
 
-  /typescript@5.0.4:
-    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
-    engines: {node: '>=12.20'}
+  /typescript@4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
+    engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,10 +71,10 @@ importers:
         version: 4.0.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^4.29.2
-        version: 4.33.0(@typescript-eslint/parser@4.33.0)(eslint@7.32.0)(typescript@4.4.4)
+        version: 4.33.0(@typescript-eslint/parser@4.33.0)(eslint@7.32.0)(typescript@5.0.4)
       '@typescript-eslint/parser':
         specifier: ^4.30.0
-        version: 4.33.0(eslint@7.32.0)(typescript@4.4.4)
+        version: 4.33.0(eslint@7.32.0)(typescript@5.0.4)
       co:
         specifier: ^4.6.0
         version: 4.6.0
@@ -154,8 +154,8 @@ importers:
         specifier: ^2.20.0
         version: 2.20.0
       typescript:
-        specifier: ~4.4.2
-        version: 4.4.4
+        specifier: ~5.0.0
+        version: 5.0.4
       webpack:
         specifier: ^5.0.0
         version: 5.88.2
@@ -641,240 +641,6 @@ importers:
       qunit-dom:
         specifier: ^3.0.0
         version: 3.0.0
-      stylelint:
-        specifier: ^15.10.3
-        version: 15.11.0(typescript@5.2.2)
-      stylelint-config-standard:
-        specifier: ^34.0.0
-        version: 34.0.0(stylelint@15.11.0)
-      stylelint-prettier:
-        specifier: ^4.0.2
-        version: 4.0.2(prettier@3.0.3)(stylelint@15.11.0)
-      tracked-built-ins:
-        specifier: ^3.2.0
-        version: 3.3.0
-      typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
-      webpack:
-        specifier: ^5.88.2
-        version: 5.88.2
-
-  test-apps/ember-concurrency-v3:
-    devDependencies:
-      '@babel/core':
-        specifier: ^7.22.20
-        version: 7.23.2
-      '@ember/optional-features':
-        specifier: ^2.0.0
-        version: 2.0.0
-      '@ember/string':
-        specifier: ^3.1.1
-        version: 3.1.1
-      '@ember/test-helpers':
-        specifier: ^3.2.0
-        version: 3.2.0(@glint/template@1.2.1)(ember-source@5.3.0)(webpack@5.88.2)
-      '@glimmer/component':
-        specifier: ^1.1.2
-        version: 1.1.2(@babel/core@7.23.2)
-      '@glimmer/tracking':
-        specifier: ^1.1.2
-        version: 1.1.2
-      '@glint/environment-ember-loose':
-        specifier: ^1.1.0
-        version: 1.2.1(@glimmer/component@1.1.2)(@glint/template@1.2.1)(@types/ember__array@4.0.7)(@types/ember__component@4.0.19)(@types/ember__controller@4.0.9)(@types/ember__object@4.0.9)(@types/ember__routing@4.0.17)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0)
-      '@glint/template':
-        specifier: ^1.1.0
-        version: 1.2.1
-      '@tsconfig/ember':
-        specifier: ^3.0.1
-        version: 3.0.1
-      '@types/ember':
-        specifier: ^4.0.4
-        version: 4.0.8(@babel/core@7.23.2)
-      '@types/ember-data':
-        specifier: ^4.4.11
-        version: 4.4.13(@babel/core@7.23.2)
-      '@types/ember-data__adapter':
-        specifier: ^4.0.2
-        version: 4.0.4(@babel/core@7.23.2)
-      '@types/ember-data__model':
-        specifier: ^4.0.1
-        version: 4.0.3(@babel/core@7.23.2)
-      '@types/ember-data__serializer':
-        specifier: ^4.0.2
-        version: 4.0.4(@babel/core@7.23.2)
-      '@types/ember-data__store':
-        specifier: ^4.0.3
-        version: 4.0.5(@babel/core@7.23.2)
-      '@types/ember__application':
-        specifier: ^4.0.7
-        version: 4.0.9(@babel/core@7.23.2)
-      '@types/ember__array':
-        specifier: ^4.0.5
-        version: 4.0.7(@babel/core@7.23.2)
-      '@types/ember__component':
-        specifier: ^4.0.16
-        version: 4.0.19(@babel/core@7.23.2)
-      '@types/ember__controller':
-        specifier: ^4.0.6
-        version: 4.0.9(@babel/core@7.23.2)
-      '@types/ember__debug':
-        specifier: ^4.0.4
-        version: 4.0.6(@babel/core@7.23.2)
-      '@types/ember__destroyable':
-        specifier: ^4.0.2
-        version: 4.0.3
-      '@types/ember__engine':
-        specifier: ^4.0.6
-        version: 4.0.8(@babel/core@7.23.2)
-      '@types/ember__error':
-        specifier: ^4.0.3
-        version: 4.0.4
-      '@types/ember__helper':
-        specifier: ^4.0.2
-        version: 4.0.4(@babel/core@7.23.2)
-      '@types/ember__modifier':
-        specifier: ^4.0.5
-        version: 4.0.7(@babel/core@7.23.2)
-      '@types/ember__object':
-        specifier: ^4.0.7
-        version: 4.0.9(@babel/core@7.23.2)
-      '@types/ember__owner':
-        specifier: ^4.0.5
-        version: 4.0.7
-      '@types/ember__polyfills':
-        specifier: ^4.0.2
-        version: 4.0.4
-      '@types/ember__routing':
-        specifier: ^4.0.14
-        version: 4.0.17(@babel/core@7.23.2)
-      '@types/ember__runloop':
-        specifier: ^4.0.5
-        version: 4.0.7(@babel/core@7.23.2)
-      '@types/ember__service':
-        specifier: ^4.0.3
-        version: 4.0.6(@babel/core@7.23.2)
-      '@types/ember__string':
-        specifier: ^3.0.11
-        version: 3.0.12
-      '@types/ember__template':
-        specifier: ^4.0.2
-        version: 4.0.4
-      '@types/ember__test':
-        specifier: ^4.0.2
-        version: 4.0.4(@babel/core@7.23.2)
-      '@types/ember__utils':
-        specifier: ^4.0.3
-        version: 4.0.5(@babel/core@7.23.2)
-      '@types/qunit':
-        specifier: ^2.19.9
-        version: 2.19.9
-      '@types/rsvp':
-        specifier: ^4.0.4
-        version: 4.0.4
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^6.7.2
-        version: 6.9.0(@typescript-eslint/parser@6.9.0)(eslint@8.52.0)(typescript@5.2.2)
-      '@typescript-eslint/parser':
-        specifier: ^6.7.2
-        version: 6.9.0(eslint@8.52.0)(typescript@5.2.2)
-      broccoli-asset-rev:
-        specifier: ^3.0.0
-        version: 3.0.0
-      concurrently:
-        specifier: ^8.2.1
-        version: 8.2.1
-      ember-auto-import:
-        specifier: ^2.6.3
-        version: 2.6.3(@glint/template@1.2.1)(webpack@5.88.2)
-      ember-cli:
-        specifier: ~5.3.0
-        version: 5.3.0
-      ember-cli-app-version:
-        specifier: ^6.0.1
-        version: 6.0.1(ember-source@5.3.0)
-      ember-cli-babel:
-        specifier: ^8.0.0
-        version: 8.2.0(@babel/core@7.23.2)
-      ember-cli-clean-css:
-        specifier: ^3.0.0
-        version: 3.0.0
-      ember-cli-dependency-checker:
-        specifier: ^3.3.2
-        version: 3.3.2(ember-cli@5.3.0)
-      ember-cli-htmlbars:
-        specifier: ^6.3.0
-        version: 6.3.0
-      ember-cli-inject-live-reload:
-        specifier: ^2.1.0
-        version: 2.1.0
-      ember-cli-sri:
-        specifier: ^2.1.1
-        version: 2.1.1
-      ember-cli-terser:
-        specifier: ^4.0.2
-        version: 4.0.2
-      ember-data:
-        specifier: ~5.3.0
-        version: 5.3.0(@babel/core@7.23.2)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.2.1)(ember-source@5.3.0)
-      ember-fetch:
-        specifier: ^8.1.2
-        version: 8.1.2
-      ember-load-initializers:
-        specifier: ^2.1.2
-        version: 2.1.2(@babel/core@7.23.2)
-      ember-modifier:
-        specifier: ^4.1.0
-        version: 4.1.0(ember-source@5.3.0)
-      ember-page-title:
-        specifier: ^8.0.0
-        version: 8.0.0
-      ember-qunit:
-        specifier: ^8.0.1
-        version: 8.0.1(@ember/test-helpers@3.2.0)(@glint/template@1.2.1)(ember-source@5.3.0)(qunit@2.20.0)
-      ember-resolver:
-        specifier: ^11.0.1
-        version: 11.0.1(ember-source@5.3.0)
-      ember-source:
-        specifier: ~5.3.0
-        version: 5.3.0(@babel/core@7.23.2)(@glimmer/component@1.1.2)(@glint/template@1.2.1)(rsvp@4.8.5)(webpack@5.88.2)
-      ember-template-lint:
-        specifier: ^5.11.2
-        version: 5.11.2
-      ember-welcome-page:
-        specifier: ^7.0.2
-        version: 7.0.2
-      eslint:
-        specifier: ^8.49.0
-        version: 8.52.0
-      eslint-config-prettier:
-        specifier: ^9.0.0
-        version: 9.0.0(eslint@8.52.0)
-      eslint-plugin-ember:
-        specifier: ^11.11.1
-        version: 11.11.1(eslint@8.52.0)
-      eslint-plugin-n:
-        specifier: ^16.1.0
-        version: 16.2.0(eslint@8.52.0)
-      eslint-plugin-prettier:
-        specifier: ^5.0.0
-        version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.52.0)(prettier@3.0.3)
-      eslint-plugin-qunit:
-        specifier: ^8.0.0
-        version: 8.0.1(eslint@8.52.0)
-      loader.js:
-        specifier: ^4.7.0
-        version: 4.7.0
-      prettier:
-        specifier: ^3.0.3
-        version: 3.0.3
-      qunit:
-        specifier: ^2.20.0
-        version: 2.20.0
-      qunit-dom:
-        specifier: ^2.0.0
-        version: 2.0.0
       stylelint:
         specifier: ^15.10.3
         version: 15.11.0(typescript@5.2.2)
@@ -6626,7 +6392,7 @@ packages:
       '@types/yargs-parser': 21.0.3
     dev: true
 
-  /@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0)(eslint@7.32.0)(typescript@4.4.4):
+  /@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0)(eslint@7.32.0)(typescript@5.0.4):
     resolution: {integrity: sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -6637,8 +6403,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.33.0(eslint@7.32.0)(typescript@4.4.4)
-      '@typescript-eslint/parser': 4.33.0(eslint@7.32.0)(typescript@4.4.4)
+      '@typescript-eslint/experimental-utils': 4.33.0(eslint@7.32.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 4.33.0(eslint@7.32.0)(typescript@5.0.4)
       '@typescript-eslint/scope-manager': 4.33.0
       debug: 4.3.4
       eslint: 7.32.0
@@ -6646,8 +6412,8 @@ packages:
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.5
-      tsutils: 3.21.0(typescript@4.4.4)
-      typescript: 4.4.4
+      tsutils: 3.21.0(typescript@5.0.4)
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6681,7 +6447,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils@4.33.0(eslint@7.32.0)(typescript@4.4.4):
+  /@typescript-eslint/experimental-utils@4.33.0(eslint@7.32.0)(typescript@5.0.4):
     resolution: {integrity: sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -6690,7 +6456,7 @@ packages:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
-      '@typescript-eslint/typescript-estree': 4.33.0(typescript@4.4.4)
+      '@typescript-eslint/typescript-estree': 4.33.0(typescript@5.0.4)
       eslint: 7.32.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@7.32.0)
@@ -6699,7 +6465,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@4.4.4):
+  /@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.0.4):
     resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -6711,10 +6477,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
-      '@typescript-eslint/typescript-estree': 4.33.0(typescript@4.4.4)
+      '@typescript-eslint/typescript-estree': 4.33.0(typescript@5.0.4)
       debug: 4.3.4
       eslint: 7.32.0
-      typescript: 4.4.4
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6786,7 +6552,7 @@ packages:
     engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@4.33.0(typescript@4.4.4):
+  /@typescript-eslint/typescript-estree@4.33.0(typescript@5.0.4):
     resolution: {integrity: sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -6801,8 +6567,8 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.5
-      tsutils: 3.21.0(typescript@4.4.4)
-      typescript: 4.4.4
+      tsutils: 3.21.0(typescript@5.0.4)
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -18046,14 +17812,14 @@ packages:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: true
 
-  /tsutils@3.21.0(typescript@4.4.4):
+  /tsutils@3.21.0(typescript@5.0.4):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.4.4
+      typescript: 5.0.4
     dev: true
 
   /type-check@0.4.0:
@@ -18104,9 +17870,9 @@ packages:
     resolution: {integrity: sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==}
     dev: true
 
-  /typescript@4.4.4:
-    resolution: {integrity: sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==}
-    engines: {node: '>=4.2.0'}
+  /typescript@5.0.4:
+    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
+    engines: {node: '>=12.20'}
     hasBin: true
     dev: true
 


### PR DESCRIPTION
We want to use ember-source's built in types for internal type checking, and we can't do that with TS < v4.9


TS v4.9 was released November of 2022