### PR TITLE
Drop support for the 'global' global. Every supported environment has `globalThis`

### DIFF
--- a/addon/addon/waiter-manager.ts
+++ b/addon/addon/waiter-manager.ts
@@ -33,7 +33,6 @@ function getGlobal(): Indexable {
   if (typeof globalThis !== 'undefined') return indexable(globalThis);
   if (typeof self !== 'undefined') return indexable(self);
   if (typeof window !== 'undefined') return indexable(window);
-  if (typeof global !== 'undefined') return indexable(global);
 
   throw new Error('unable to locate global object');
 }


### PR DESCRIPTION
tl;dr: I didn't want to figure out how to type `global` as a global, and since only node has `global`... we don't need to care about its existence (since any js runtime that has `global` also has `globalThis` -- which we do support)

for node / fastboot, `globalThis` was introduced in Node 12, which we already don't support as it's far beyond LTS support period. Prior to Node 12, this library will no longer work in fastboot mode (so you'd have to use `v3.x` of test-waiters).