### PR TITLE
Remove macros from dependencies as it's not needed (consumer must provide macros-handling plugin)

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -25,12 +25,12 @@
     "prepack": "pnpm build"
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.9.0",
-    "@embroider/macros": "^1.16.9"
+    "@embroider/addon-shim": "^1.9.0"
   },
   "devDependencies": {
     "@babel/plugin-transform-typescript": "^7.25.9",
     "@embroider/addon-dev": "^7.0.0",
+    "@embroider/macros": "^1.16.9",
     "@eslint/js": "^9.16.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@tsconfig/ember": "^3.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       '@embroider/addon-shim':
         specifier: ^1.9.0
         version: 1.9.0
-      '@embroider/macros':
-        specifier: ^1.16.9
-        version: 1.16.9(@glint/template@1.5.0)
     devDependencies:
       '@babel/plugin-transform-typescript':
         specifier: ^7.25.9
@@ -42,6 +39,9 @@ importers:
       '@embroider/addon-dev':
         specifier: ^7.0.0
         version: 7.0.0(@glint/template@1.5.0)(rollup@4.28.0)
+      '@embroider/macros':
+        specifier: ^1.16.9
+        version: 1.16.9(@glint/template@1.5.0)
       '@eslint/js':
         specifier: ^9.16.0
         version: 9.16.0


### PR DESCRIPTION
title

ember 7 tests are failing, but that's expected because the test suite in this repo hasn't been updated to work with ember 7 -- has no impact on actual compatibility with ember 7 -- kinda looks like ember-cli needs updated