### PR TITLE
[SPIKE] waitersSettled(): await waiter completion instead of polling for it

### DIFF
--- a/addon/src/build-waiter.ts
+++ b/addon/src/build-waiter.ts
@@ -15,6 +15,21 @@ function getNextToken(): Token {
   return new Token();
 }
 
+/**
+ * A promise that carries its own resolver, so a collection of pending
+ * operations holds nothing but the promises themselves.
+ */
+type ResolvablePromise = Promise<void> & { resolve: () => void };
+
+function resolvablePromise(): ResolvablePromise {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => (resolve = r)) as ResolvablePromise;
+
+  promise.resolve = resolve;
+
+  return promise;
+}
+
 class TestWaiterImpl<T extends object | Primitive = Token> implements TestWaiter<T> {
   public name: WaiterName;
   private nextToken: () => T;
@@ -23,6 +38,14 @@ class TestWaiterImpl<T extends object | Primitive = Token> implements TestWaiter
   items = new Map<T, TestWaiterDebugInfo>();
   completedOperationsForTokens = new WeakMap<Token, boolean>();
   completedOperationsForPrimitives = new Map<Primitive, boolean>();
+
+  /**
+   * The completion promise for each pending operation, keyed by token so
+   * `endAsync` can settle its own. Values are the promises themselves,
+   * each carrying its resolver, and an entry is dropped as it resolves --
+   * so this only ever holds operations still in flight.
+   */
+  private pendingPromises = new Map<T, ResolvablePromise>();
 
   constructor(name: WaiterName, nextToken?: () => T) {
     this.name = name;
@@ -47,6 +70,8 @@ class TestWaiterImpl<T extends object | Primitive = Token> implements TestWaiter
       label,
     });
 
+    this.pendingPromises.set(token, resolvablePromise());
+
     return token;
   }
 
@@ -64,6 +89,13 @@ class TestWaiterImpl<T extends object | Primitive = Token> implements TestWaiter
     // Mark when a waiter operation has completed so we can distinguish
     // whether endAsync is being called before a prior beginAsync call above.
     this._getCompletedOperations(token).set(token, true);
+
+    const pending = this.pendingPromises.get(token);
+
+    if (pending !== undefined) {
+      this.pendingPromises.delete(token);
+      pending.resolve();
+    }
   }
 
   waitUntil(): boolean {
@@ -80,8 +112,20 @@ class TestWaiterImpl<T extends object | Primitive = Token> implements TestWaiter
     return result;
   }
 
+  settled(): Promise<unknown> {
+    return Promise.all(this.pendingPromises.values());
+  }
+
   reset(): void {
     this.items.clear();
+
+    // anything awaiting these would otherwise wait on operations this
+    // waiter has stopped tracking
+    for (const pending of this.pendingPromises.values()) {
+      pending.resolve();
+    }
+
+    this.pendingPromises.clear();
   }
 
   private _register(): void {

--- a/addon/src/index.ts
+++ b/addon/src/index.ts
@@ -15,6 +15,7 @@ export {
   _reset,
   getPendingWaiterState,
   hasPendingWaiters,
+  waitersSettled,
 } from './waiter-manager.ts';
 
 export { default as buildWaiter, _resetWaiterNames } from './build-waiter.ts';

--- a/addon/src/types/index.ts
+++ b/addon/src/types/index.ts
@@ -50,6 +50,21 @@ export interface Waiter {
    * @returns {TestWaiterDebugInfo}
    */
   debugInfo(): TestWaiterDebugInfo[];
+
+  /**
+   * Resolves when the operations this waiter is currently tracking have
+   * completed, so callers can await completion rather than polling
+   * `waitUntil`. Operations begun after the call are not included --
+   * callers that need a fixpoint should re-check.
+   *
+   * Optional: a waiter that cannot know when it goes quiet may omit it,
+   * and `waitersSettled` will treat this waiter as un-announceable.
+   *
+   * @public
+   * @method settled
+   * @returns {Promise<unknown>} resolves when the tracked operations complete
+   */
+  settled?(): Promise<unknown>;
 }
 
 /**

--- a/addon/src/waiter-manager.ts
+++ b/addon/src/waiter-manager.ts
@@ -118,3 +118,38 @@ export function hasPendingWaiters(): boolean {
 
   return state.pending > 0;
 }
+
+/**
+ * Never resolves. Returned when a pending waiter cannot announce its own
+ * completion, so callers fall through to whatever fallback they race
+ * this against rather than being told, wrongly, that things are quiet.
+ */
+const NEVER: Promise<unknown> = new Promise(() => {});
+
+/**
+ * Resolves when the operations all waiters are currently tracking have
+ * completed, composed from the waiters' own completion promises rather
+ * than by polling `hasPendingWaiters`.
+ *
+ * Operations begun after this call are not included: settling can start
+ * more work, so a caller that needs a true fixpoint re-checks. And a
+ * pending waiter that does not implement `settled` cannot announce
+ * anything, so this never resolves while one is outstanding -- race it
+ * against a fallback tick if you must tolerate those.
+ *
+ * @public
+ * @returns {Promise<unknown>} resolves when the tracked operations complete
+ */
+export function waitersSettled(): Promise<unknown> {
+  const settled: Promise<unknown>[] = [];
+
+  for (const waiter of getWaiters()) {
+    if (typeof waiter.settled === 'function') {
+      settled.push(waiter.settled());
+    } else if (!waiter.waitUntil()) {
+      return NEVER;
+    }
+  }
+
+  return Promise.all(settled);
+}


### PR DESCRIPTION
Companion to emberjs/ember-test-helpers#1574, exploring the RFC 957 test story (context: emberjs/ember.js#21520). Draft for discussion.

## The idea

Waiters already know the moment each operation completes, but consumers can only find out by polling `hasPendingWaiters()` on a timer. So:

- `beginAsync` creates a promise for that operation,
- `endAsync` resolves it and drops it from the pending map — which therefore only ever holds work still in flight,
- `waitersSettled()` composes the promises of whatever is currently tracked,
- and `Waiter` gains an optional `settled()` so each waiter answers for its own operations.

`NoopTestWaiter` (production) resolves immediately; nothing changes for non-test builds.

## Two honest limits, both reflected in the API

**Operations begun after the call are not included.** Settling can start more work, so `waitersSettled()` is a snapshot, and a caller that needs a true fixpoint re-checks. (The companion `settled()` loops.)

**A `Waiter` implemented directly against the interface may not implement `settled()`** — its `waitUntil` is pull-only and nothing obliges it to announce anything. Rather than claiming a quiet it cannot verify, `waitersSettled()` returns a **never-resolving** promise while such a waiter is pending, so callers race it against their own fallback tick and the pull-only waiter still works.

## Does it actually do the work?

Measured, not assumed. Instrumenting the companion `settled()` to record which side of the race won, in an app whose suite exercises workers, rendering, and compilation: **91 of 92 iterations decided by the promises**, 1 by the fallback.

That measurement also surfaced a sharp edge worth recording: the fallback tick must be slower than a frame. At 10ms it beat *frame-paced render ticks* to the race and decided 30 of 117 iterations, costing an extra loop pass each time; at 50ms, 1 of 92.

## Validation

- This repo's `base-tests` app: **56/56**.
- `@ember/test-helpers` test-app against a linked build of this branch: **553/553**; against published `@ember/test-waiters` (no `waitersSettled`, degraded to the fallback tick): **553/553**.
- Against the runloop-less ember spike: limber's full chrome matrix green, 7/7 repeat runs on the suite that exposed the macrotask-confirm flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)